### PR TITLE
design: create garden view

### DIFF
--- a/ForestTori/ForestTori.xcodeproj/project.pbxproj
+++ b/ForestTori/ForestTori.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		5BA931152B62604800F48AF1 /* Chapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA931142B62604800F48AF1 /* Chapter.swift */; };
 		5BA931172B62605D00F48AF1 /* Mission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA931162B62605D00F48AF1 /* Mission.swift */; };
 		5BA931192B6260CC00F48AF1 /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA931182B6260CC00F48AF1 /* DataManager.swift */; };
+		5BABC2C92B899D8B00C74E3C /* GardenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BABC2C82B899D8B00C74E3C /* GardenView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -169,6 +170,7 @@
 		5BA931142B62604800F48AF1 /* Chapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chapter.swift; sourceTree = "<group>"; };
 		5BA931162B62605D00F48AF1 /* Mission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mission.swift; sourceTree = "<group>"; };
 		5BA931182B6260CC00F48AF1 /* DataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
+		5BABC2C82B899D8B00C74E3C /* GardenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GardenView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -449,6 +451,7 @@
 				5B68A4252B8454790004E89A /* ServieStateView.swift */,
 				0E1AE7012B7E1883001C9A30 /* Main */,
 				5B9152A62B834AD90068418F /* Onboarding */,
+				5B314A222B8DE06300719C55 /* Garden */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -496,6 +499,14 @@
 				0EF5FEAA2B4FC39300D64E5E /* Utils */,
 			);
 			path = Source;
+			sourceTree = "<group>";
+		};
+		5B314A222B8DE06300719C55 /* Garden */ = {
+			isa = PBXGroup;
+			children = (
+				5BABC2C82B899D8B00C74E3C /* GardenView.swift */,
+			);
+			path = Garden;
 			sourceTree = "<group>";
 		};
 		5B7E02AE2B5FE8BE0067B2FA /* CharacterDialogues */ = {
@@ -701,6 +712,7 @@
 				5B68A4352B845DFE0004E89A /* Font+.swift in Sources */,
 				5BA395442B7252C00019A545 /* GameManager.swift in Sources */,
 				0E1AE7002B7E1880001C9A30 /* MainView.swift in Sources */,
+				5BABC2C92B899D8B00C74E3C /* GardenView.swift in Sources */,
 				0E1AE7032B7E1892001C9A30 /* PlantView.swift in Sources */,
 				5B68A4372B845E200004E89A /* View+.swift in Sources */,
 				5BA395842B82495B0019A545 /* OnboardingNamingView.swift in Sources */,

--- a/ForestTori/ForestTori/Source/View/Garden/GardenView.swift
+++ b/ForestTori/ForestTori/Source/View/Garden/GardenView.swift
@@ -1,0 +1,118 @@
+//
+//  GardenView.swift
+//  ForestTori
+//
+//  Created by Nayeon Kim on 2/24/24.
+//
+
+import SwiftUI
+
+struct GardenView: View {
+    private let noPlantCaption = "아직 다 키운 식물이 없어요."
+    
+    var body: some View {
+        NavigationView {
+            ZStack {
+                Image(.springBackground)
+                    .resizable()
+                    .scaledToFit()
+                
+                VStack(spacing: 40) {
+                    Spacer()
+                    Spacer()
+                    Spacer()
+                    
+                    // TODO: 정원 오브젝트로 변경
+                    Image(.onboardingFrezia)
+                        .resizable()
+                        .scaledToFit()
+                    
+                    noPlantCaptionBox
+                    
+                    Spacer()
+                    Spacer()
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    toMainButton
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    totalProgressBar
+                }
+                ToolbarItem(placement: .bottomBar) {
+                    ARButton
+                }
+            }
+            .ignoresSafeArea()
+        }
+    }
+}
+
+// MARK: - toMainButton
+
+extension GardenView {
+    @ViewBuilder private var toMainButton: some View {
+        Button {
+            // action
+        } label: {
+            Image(.gardenButton)
+        }
+        .padding(.top)
+    }
+}
+
+// MARK: - totalProgressBar
+
+extension GardenView {
+    @ViewBuilder private var totalProgressBar: some View {
+        ZStack {
+            Image(.gardenProgressSpring3)
+            VStack {
+                Text("봄, 숲을 만나다")
+                    .font(.titleS)
+                Text("21%")
+                    .font(.titleL)
+            }
+            .foregroundColor(.white)
+            .shadow(color: .gray30, radius: 4.0)
+        }
+        .padding(.top)
+    }
+}
+
+// MARK: - noPlantCaptionBox
+
+extension GardenView {
+    @ViewBuilder private var noPlantCaptionBox: some View {
+        Text(noPlantCaption)
+            .font(.bodyM)
+            .foregroundColor(.white)
+            .padding(.horizontal, 25)
+            .padding(.vertical, 6)
+            .background {
+                Capsule()
+                    .foregroundColor(.black)
+                    .opacity(0.4)
+            }
+    }
+}
+
+// MARK: - ARButton
+
+extension GardenView {
+    @ViewBuilder private var ARButton: some View {
+        Button {
+            // action
+        } label: {
+            Image(.arButton)
+                .resizable()
+                .scaledToFit()
+                .frame(maxWidth: 50.0, minHeight: 50.0)
+        }
+    }
+}
+
+#Preview {
+    GardenView()
+}


### PR DESCRIPTION
## 📌 Summary
#22 

<br>

## ✨ Description
프로토타입에 맞춰 정원 뷰의 UI 레이아웃을 구현하였습니다.
- 상단과 하단의 UI 요소(버튼, 프로그레스바)는 toolbar를 이용해서 배치하였습니다.
```swift
.toolbar {
                ToolbarItem(placement: .topBarLeading) {
                    toMainButton
                }
                ToolbarItem(placement: .topBarTrailing) {
                    totalProgressBar
                }
                ToolbarItem(placement: .bottomBar) {
                    ARButton
                }
            }
```
- 현재는 정원 오브젝트 대신 임의의 이미지(프리지아)를 배치시켰습니다.
   - 정원 오브젝트의 경우, 작업을 따로 분리하여 추후에 진행할 예정입니다.

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|정원|<img src ="https://github.com/DevTillDie/ForestTori/assets/97589973/eb4d2366-5c14-4f42-8bc6-36f7ad085e15" width ="250">|

<br>

## 🗒️ Review Point
```
일단, UI 레이아웃 배치 확인용 코드라, 코드 자체가 깔끔하지는 않습니다.
해당 부분 양해 부탁드리고, View 구조 위주로 검토해 주세요!

p.s.
UI 작업의 경우, 추후 기기 대응에 유연하게 대처할 수 있는 방향으로 작업을 진행하고 싶습니다.
따라서, .padding()과 .offset()으로 위치를 조정하기보다는 Spacer()로 진행을 하고 있기는 한데 이 부분에 대해서도 어떤 방식이 최선인지 다 함께 의논하면 좋을 것 같네요. 
```
