### PR TITLE
feat: add ending process

### DIFF
--- a/ForestTori/ForestTori.xcodeproj/project.pbxproj
+++ b/ForestTori/ForestTori.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		5B68A4342B845DDE0004E89A /* ModifierInitFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B68A4332B845DDE0004E89A /* ModifierInitFile.swift */; };
 		5B68A4352B845DFE0004E89A /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E1AE6FD2B7E185B001C9A30 /* Font+.swift */; };
 		5B68A4372B845E200004E89A /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B68A4362B845E200004E89A /* View+.swift */; };
+		5B72DDC82B91BA8B002EA734 /* EndingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B72DDC72B91BA8B002EA734 /* EndingViewModel.swift */; };
 		5B9152A82B84402C0068418F /* OnboardingTextBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9152A72B84402C0068418F /* OnboardingTextBox.swift */; };
 		5BA395442B7252C00019A545 /* GameManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA395432B7252C00019A545 /* GameManager.swift */; };
 		5BA3955C2B7E359F0019A545 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA3955B2B7E359F0019A545 /* OnboardingView.swift */; };
@@ -83,6 +84,7 @@
 		5BA395842B82495B0019A545 /* OnboardingNamingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA395832B82495B0019A545 /* OnboardingNamingView.swift */; };
 		5BA395862B824D950019A545 /* NameSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA395852B824D950019A545 /* NameSettingView.swift */; };
 		5BA395882B826CEA0019A545 /* OnboardingCompletionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA395872B826CEA0019A545 /* OnboardingCompletionView.swift */; };
+		5BA885842B90698900041393 /* EndingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA885832B90698900041393 /* EndingView.swift */; };
 		5BA931112B62602200F48AF1 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA931102B62602200F48AF1 /* User.swift */; };
 		5BA931132B62603200F48AF1 /* Plant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA931122B62603200F48AF1 /* Plant.swift */; };
 		5BA931152B62604800F48AF1 /* Chapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA931142B62604800F48AF1 /* Chapter.swift */; };
@@ -151,6 +153,7 @@
 		5B68A4252B8454790004E89A /* ServieStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServieStateView.swift; sourceTree = "<group>"; };
 		5B68A4332B845DDE0004E89A /* ModifierInitFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModifierInitFile.swift; sourceTree = "<group>"; };
 		5B68A4362B845E200004E89A /* View+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
+		5B72DDC72B91BA8B002EA734 /* EndingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndingViewModel.swift; sourceTree = "<group>"; };
 		5B9152A72B84402C0068418F /* OnboardingTextBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTextBox.swift; sourceTree = "<group>"; };
 		5BA395432B7252C00019A545 /* GameManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameManager.swift; sourceTree = "<group>"; };
 		5BA395562B7E2EE80019A545 /* Font+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Font+.swift"; sourceTree = "<group>"; };
@@ -169,6 +172,7 @@
 		5BA395832B82495B0019A545 /* OnboardingNamingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingNamingView.swift; sourceTree = "<group>"; };
 		5BA395852B824D950019A545 /* NameSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameSettingView.swift; sourceTree = "<group>"; };
 		5BA395872B826CEA0019A545 /* OnboardingCompletionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCompletionView.swift; sourceTree = "<group>"; };
+		5BA885832B90698900041393 /* EndingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndingView.swift; sourceTree = "<group>"; };
 		5BA931102B62602200F48AF1 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		5BA931122B62603200F48AF1 /* Plant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plant.swift; sourceTree = "<group>"; };
 		5BA931142B62604800F48AF1 /* Chapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chapter.swift; sourceTree = "<group>"; };
@@ -467,6 +471,7 @@
 			children = (
 				0E1AE7102B80A77A001C9A30 /* MainViewModel.swift */,
 				5BA395632B7E4A230019A545 /* OnboardingViewModel.swift */,
+				5B72DDC72B91BA8B002EA734 /* EndingViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -500,6 +505,7 @@
 			isa = PBXGroup;
 			children = (
 				0EF5FEA72B4FC2F500D64E5E /* View */,
+				5BA885832B90698900041393 /* EndingView.swift */,
 				0EF5FEA82B4FC2FC00D64E5E /* ViewModel */,
 				0EF5FEA92B4FC30300D64E5E /* Model */,
 				0EF5FEAA2B4FC39300D64E5E /* Utils */,
@@ -722,6 +728,7 @@
 				0E1AE7032B7E1892001C9A30 /* PlantView.swift in Sources */,
 				5B68A4372B845E200004E89A /* View+.swift in Sources */,
 				5BA395842B82495B0019A545 /* OnboardingNamingView.swift in Sources */,
+				5BA885842B90698900041393 /* EndingView.swift in Sources */,
 				5B68A4262B8454790004E89A /* ServieStateView.swift in Sources */,
 				5BA3957F2B8235AF0019A545 /* OnboardingSkipButton.swift in Sources */,
 				0E58AB842B8CAD1C00EB8C78 /* PlantCardView.swift in Sources */,
@@ -731,6 +738,7 @@
 				0E1AE7052B7E18AF001C9A30 /* PlantPotView.swift in Sources */,
 				5BA395862B824D950019A545 /* NameSettingView.swift in Sources */,
 				0EF5FE962B4FC02100D64E5E /* ForestToriApp.swift in Sources */,
+				5B72DDC82B91BA8B002EA734 /* EndingViewModel.swift in Sources */,
 				5B9152A82B84402C0068418F /* OnboardingTextBox.swift in Sources */,
 				5BA3955E2B7E377D0019A545 /* OnboardingGreetingView.swift in Sources */,
 				0E58AB822B85BF5C00EB8C78 /* SelectPlantView.swift in Sources */,

--- a/ForestTori/ForestTori.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ForestTori/ForestTori.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "realm-core",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/realm-core.git",
+      "state" : {
+        "revision" : "a5e87a39cffdcc591f3203c11cfca68100d0b9a6",
+        "version" : "13.26.0"
+      }
+    },
+    {
+      "identity" : "realm-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/realm-swift.git",
+      "state" : {
+        "branch" : "master",
+        "revision" : "bf892749c7dcc6d1714e7d47d217390a49ba1238"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/ForestTori/ForestTori/Info.plist
+++ b/ForestTori/ForestTori/Info.plist
@@ -2,6 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIAppFonts</key>
+	<array>
+		<string>Pretendard-Light.ttf</string>
+		<string>Pretendard-Regular.ttf</string>
+		<string>Pretendard-SemiBold.ttf</string>
+		<string>Pretendard-Bold.ttf</string>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIColorName</key>

--- a/ForestTori/ForestTori/Source/EndingView.swift
+++ b/ForestTori/ForestTori/Source/EndingView.swift
@@ -1,0 +1,92 @@
+//
+//  EndingView.swift
+//  ForestTori
+//
+//  Created by Nayeon Kim on 2/29/24.
+//
+
+import SwiftUI
+
+struct EndingView: View {
+    @ObservedObject var endingViewModel: EndingViewModel
+    
+    @State var isHidden = false
+    @State var textIndex = 0
+    @State var timer: Timer?
+    
+    private let doneButtonLabel = "메인으로"
+    private let lastIndex = 4
+    
+    var body: some View {
+        NavigationView {
+            ZStack {
+                Color.yellowTertiary
+                    .ignoresSafeArea()
+                
+                ZStack {
+                    VStack(spacing: 30) {
+                        Image(.onboardingFrezia)
+                            .resizable()
+                            .scaledToFit()
+                        
+                        OnboardingTextBox(texts: endingViewModel.endingTexts[textIndex])
+                            .font(.titleL)
+                            .foregroundColor(.brownPrimary)
+                    }
+                    
+                    VStack {
+                        Spacer()
+                        
+                        OnboardingDoneButton(action: endingViewModel.completeEndingProcess, label: doneButtonLabel)
+                            .foregroundColor(.yellowTertiary)
+                            .background {
+                                RoundedRectangle(cornerRadius: 50)
+                                    .fill(.brownPrimary)
+                            }
+                            .hidden(isHidden)
+                    }
+                }
+                .padding(20)
+                .toolbar {
+                    OnboardingSkipButton(action: skipToLastText)
+                }
+            }
+            .onAppear {
+                increaseTextIndex()
+            }
+        }
+    }
+}
+
+// MARK: - functions
+
+extension EndingView {
+    private func skipToLastText() {
+        stopTimer()
+        withAnimation(.easeInOut(duration: 1)) {
+            textIndex = lastIndex
+            isHidden = true
+        }
+    }
+
+    private func stopTimer() {
+        timer?.invalidate()
+    }
+    
+    private func increaseTextIndex() {
+        timer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { _ in
+            if textIndex < lastIndex {
+                withAnimation(.easeInOut(duration: 1.5)) {
+                    textIndex += 1
+                }
+            } else {
+                stopTimer()
+                isHidden = true
+            }
+        }
+    }
+}
+
+#Preview {
+    EndingView(endingViewModel: EndingViewModel())
+}

--- a/ForestTori/ForestTori/Source/View/Onboarding/OnboardingNamingView.swift
+++ b/ForestTori/ForestTori/Source/View/Onboarding/OnboardingNamingView.swift
@@ -16,6 +16,7 @@ struct OnboardingNamingView: View {
     @State var timer: Timer?
     
     private let doneButtonLabel = "시작하기"
+    private let lastIndex = 3
     
     var body: some View {
         VStack(spacing: 30) {
@@ -78,7 +79,7 @@ extension OnboardingNamingView {
                 textIndex += 1
             }
             
-            if textIndex > 2 {
+            if textIndex == lastIndex {
                 stopTimer()
                 Timer.scheduledTimer(withTimeInterval: 2.5, repeats: false) { _ in
                         onboardingViewModel.moveToOnboardingCompletionView()

--- a/ForestTori/ForestTori/Source/ViewModel/EndingViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/EndingViewModel.swift
@@ -1,0 +1,70 @@
+//
+//  EndingViewModel.swift
+//  ForestTori
+//
+//  Created by Nayeon Kim on 3/1/24.
+//
+
+import Foundation
+import SwiftUI
+
+///  EndingView에서 사용하는 데이터를 관리하는 클래스
+///
+///  - endingTexts: 엔딩에서 사용하는 텍스트 데이터 집합
+class EndingViewModel: ObservableObject {
+    @Published var endingTexts: [[OnboardingText]] = []
+    
+    // TODO: 사용자 관련 변수 분리해서 관리하기
+    let onboardingViewModel = OnboardingViewModel()
+    let userName: String
+    
+    init() {
+        self.userName = onboardingViewModel.userName
+        setEndingTexts()
+    }
+}
+
+extension EndingViewModel {
+    func completeEndingProcess() {
+        // TODO: 엔딩 완료 함수 수정
+        print("complete ending process")
+    }
+}
+
+// MARK: Data Initialization
+
+extension EndingViewModel {
+    private func setEndingTexts() {
+        let firstText = [
+            OnboardingText(text: "\(Text(userName).foregroundColor(.greenPrimary))"),
+            OnboardingText(text: "정말 열심히 식물을 키워주었군요!"),
+            OnboardingText(text: "정원이 예쁜 식물들로 가득해졌네요."),
+        ]
+        
+        let secondText = [
+            OnboardingText(text: "그런데, 여길 봐요!"),
+            OnboardingText(text: "방금 새 싹을 틔운 화분 하나가 남아있어요."),
+            OnboardingText(text: " ")
+        ]
+        
+        let thirdText = [
+            OnboardingText(text: "사실, 이 새싹은 바로"),
+            OnboardingText(text: "\(Text(userName).foregroundColor(.greenPrimary)) 당신이에요."),
+            OnboardingText(text: " "),
+        ]
+        
+        let fourthText = [
+            OnboardingText(text: "이제는 토리의 숲을 벗어나"),
+            OnboardingText(text: "더 넓은 세상에서 자라날 준비가 된 것 같네요."),
+            OnboardingText(text: " ")
+        ]
+        
+        let fifthText = [
+            OnboardingText(text: "토리의 숲이 그리워질 때면,"),
+            OnboardingText(text: "언제든 다시 찾아와요."),
+            OnboardingText(text: " ")
+        ]
+        
+        endingTexts = [firstText, secondText, thirdText, fourthText, fifthText]
+    }
+}

--- a/ForestTori/ForestTori/Source/ViewModel/OnboardingViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/OnboardingViewModel.swift
@@ -16,8 +16,8 @@ import SwiftUI
 /// - onboardingNamingTexts: 사용자 이름 설정 단계에서 사용하는 텍스트 집합
 /// - onboardingCompletionText: 온보딩 완료 단계에서 사용하는 텍스트 집합
 class OnboardingViewModel: ObservableObject {
-//    @AppStorage("_isFirstLaunching") var isFirstLaunching = true
-    @Published var isFirstLaunching = true
+    @AppStorage("_isFirstLaunching") var isFirstLaunching = true
+    // TODO: 사용자 관련 변수 분리해서 관리하기
     @AppStorage("userName") var userName = ""
     
     @Published var type: OnboardingType = .greeting


### PR DESCRIPTION
## 📌 Summary
close #28 

<br>

## ✨ Description
엔딩 과정을 구현하였습니다.
- `EndingViewModel`을 통해 프리지아 대사 데이터를 관리하고 있습니다.
- Onbaording을 위해 생성하였던 컴포넌트를 재사용하여 UI를 구현하였습니다.

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|엔딩|<img src = "https://github.com/DevTillDie/ForestTori/assets/97589973/8830c621-ae5f-4eb2-8f0c-37d4e312f97f" width ="250">|

<br>

## 🗒️ Review Point
```
현재는 "엔딩" 과정 자체만 구현이 되어 있습니다. 
각 단계를 전환하는 로직은 다음 작업에서 진행될 것 입니다.
아마, 이 과정에서 각 단계에서 공통적으로 사용하는 변수에 대한 정리를 추가적으로 진행할 것 같습니다.
(예시- 현재 사용자 닉네임은 OnboardingViewModel에서 단독으로 관리 중)

공유하고 싶거나 제안하고 싶은 의견 있다면 자유롭게 남겨주세요!
```
