### PR TITLE
feat: show garden object

### DIFF
--- a/ForestTori/ForestTori.xcodeproj/project.pbxproj
+++ b/ForestTori/ForestTori.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		5BA931172B62605D00F48AF1 /* Mission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA931162B62605D00F48AF1 /* Mission.swift */; };
 		5BA931192B6260CC00F48AF1 /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA931182B6260CC00F48AF1 /* DataManager.swift */; };
 		5BABC2C92B899D8B00C74E3C /* GardenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BABC2C82B899D8B00C74E3C /* GardenView.swift */; };
+		5BE2F6302BC03AF90049A988 /* GardenScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE2F62F2BC03AF90049A988 /* GardenScene.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -181,6 +182,7 @@
 		5BA931162B62605D00F48AF1 /* Mission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mission.swift; sourceTree = "<group>"; };
 		5BA931182B6260CC00F48AF1 /* DataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
 		5BABC2C82B899D8B00C74E3C /* GardenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GardenView.swift; sourceTree = "<group>"; };
+		5BE2F62F2BC03AF90049A988 /* GardenScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GardenScene.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -290,6 +292,7 @@
 			children = (
 				5BA395822B8235D40019A545 /* Buttons */,
 				5B9152A92B8440300068418F /* TextBoxes */,
+				5BE2F6312BC03B000049A988 /* Scenes */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -584,6 +587,14 @@
 			path = Buttons;
 			sourceTree = "<group>";
 		};
+		5BE2F6312BC03B000049A988 /* Scenes */ = {
+			isa = PBXGroup;
+			children = (
+				5BE2F62F2BC03AF90049A988 /* GardenScene.swift */,
+			);
+			path = Scenes;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -745,6 +756,7 @@
 				0E58AB842B8CAD1C00EB8C78 /* PlantCardView.swift in Sources */,
 				5BA931152B62604800F48AF1 /* Chapter.swift in Sources */,
 				5B68A4342B845DDE0004E89A /* ModifierInitFile.swift in Sources */,
+				5BE2F6302BC03AF90049A988 /* GardenScene.swift in Sources */,
 				5BA931132B62603200F48AF1 /* Plant.swift in Sources */,
 				0E1AE7052B7E18AF001C9A30 /* PlantPotView.swift in Sources */,
 				5BA395862B824D950019A545 /* NameSettingView.swift in Sources */,

--- a/ForestTori/ForestTori.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ForestTori/ForestTori.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "182db11c87d1734fe53a6366b674339f70901a93290bd85def29b63e25e34c43",
   "pins" : [
     {
       "identity" : "realm-core",
@@ -20,5 +19,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/ForestTori/ForestTori/Source/Utils/Component/Scenes/GardenScene.swift
+++ b/ForestTori/ForestTori/Source/Utils/Component/Scenes/GardenScene.swift
@@ -1,0 +1,92 @@
+//
+//  GardenScene.swift
+//  ForestTori
+//
+//  Created by Nayeon Kim on 4/5/24.
+//
+
+import SwiftUI
+
+import SceneKit
+
+struct GardenScene: UIViewRepresentable {
+    @EnvironmentObject var gameManager: GameManager
+    
+    private let gardenObject = "Gardenground.scn"
+    private let lightNode = SCNNode()
+    private let sceneView = SCNView()
+    
+    func makeUIView(context: Context) -> some UIView {
+        setSceneView()
+        
+        // TODO: gameManager 연결
+        guard let newNode = addNode() else {
+            return sceneView
+        }
+        sceneView.scene?.rootNode.addChildNode(newNode)
+        
+        return sceneView
+    }
+    
+    func updateUIView(_ uiView: UIViewType, context: Context) {
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+    class Coordinator: NSObject {
+        let parent: GardenScene
+        
+        init(_ parent: GardenScene) {
+            self.parent = parent
+        }
+    }
+}
+
+extension GardenScene {
+    private func setSceneView() -> Void {
+        lightNode.light = SCNLight()
+        lightNode.light?.type = .omni
+        lightNode.light?.intensity = 10000
+        lightNode.position = SCNVector3(x: 100, y: 100, z: 100)
+        
+        sceneView.backgroundColor = .clear
+        sceneView.scene = SCNScene(named: gardenObject)
+        sceneView.scene?.rootNode.scale = SCNVector3(x: 1.0, y: 1.0, z: 1.0)
+        
+        sceneView.scene?.rootNode.addChildNode(lightNode)
+        
+        sceneView.autoenablesDefaultLighting = true
+        sceneView.allowsCameraControl = true
+        sceneView.defaultCameraController.maximumVerticalAngle = 30
+        
+        // UIPanGestureRecognizer를 제외한 모든 gesture 비활성화
+        if let gestureRecognizers = sceneView.gestureRecognizers {
+            for gestureRecognizer in gestureRecognizers where !(gestureRecognizer is UIPanGestureRecognizer) {
+                gestureRecognizer.isEnabled = false
+            }
+        }
+    }
+    
+    private func addNode() -> SCNNode? {
+        let plantNode = SCNNode()
+        
+        guard let plantScene = SCNScene(named: "Dandelion3.scn") else {
+            return nil
+        }
+        
+        let node = SCNNode()
+        
+        for childNode in plantScene.rootNode.childNodes {
+            node.addChildNode(childNode)
+        }
+        
+        node.position = SCNVector3(x: 0.0, y: 1.0, z: 0.0)
+        node.scale = SCNVector3(x: 0.8, y: 0.8, z: 0.8)
+        
+        plantNode.addChildNode(node)
+        
+        return plantNode
+    }
+}

--- a/ForestTori/ForestTori/Source/View/Garden/GardenView.swift
+++ b/ForestTori/ForestTori/Source/View/Garden/GardenView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct GardenView: View {
+    @StateObject var gameManager: GameManager
     private let noPlantCaption = "아직 다 키운 식물이 없어요."
     
     var body: some View {
@@ -20,14 +21,12 @@ struct GardenView: View {
                 VStack(spacing: 40) {
                     Spacer()
                     Spacer()
-                    Spacer()
                     
-                    // TODO: 정원 오브젝트로 변경
-                    Image(.onboardingFrezia)
-                        .resizable()
+                    GardenScene()
                         .scaledToFit()
                     
                     noPlantCaptionBox
+                        .hidden(gameManager.user.completedPlants.isEmpty)
                     
                     Spacer()
                     Spacer()
@@ -114,5 +113,5 @@ extension GardenView {
 }
 
 #Preview {
-    GardenView()
+    GardenView(gameManager: GameManager())
 }


### PR DESCRIPTION
## 📌 Summary
- resolve: #36 

<br>

## ✨ Description
- 정원 뷰에서 정원 3D 오브젝트와 식물 오브젝트를 불러오는 코드를 작성하였습니다.
- 현재는 샘플 코드로, 스토리 진행 상황과 상관 없이 민들레 오브젝트만 불러옵니다.
- `lightNode`를 추가하여 해당 씬을 밝혀주었습니다.
```swift
private func setSceneView() -> Void {
        lightNode.light = SCNLight()
        lightNode.light?.type = .omni
        lightNode.light?.intensity = 10000
        lightNode.position = SCNVector3(x: 100, y: 100, z: 100)
        
        sceneView.backgroundColor = .clear
        sceneView.scene = SCNScene(named: gardenObject)
        sceneView.scene?.rootNode.scale = SCNVector3(x: 1.0, y: 1.0, z: 1.0)
        
        sceneView.scene?.rootNode.addChildNode(lightNode)
        
        sceneView.autoenablesDefaultLighting = true
        sceneView.allowsCameraControl = true
        sceneView.defaultCameraController.maximumVerticalAngle = 30
        
        // UIPanGestureRecognizer를 제외한 모든 gesture 비활성화
        if let gestureRecognizers = sceneView.gestureRecognizers {
            for gestureRecognizer in gestureRecognizers where !(gestureRecognizer is UIPanGestureRecognizer) {
                gestureRecognizer.isEnabled = false
            }
        }
    }
```
- 씬에 식물 오브젝트를 추가하는 코드입니다. `GameManager`와 연결하여 성장이 완료한 식물을 정원에 추가할 예정입니다.
```swift
private func addNode() -> SCNNode? {
        let plantNode = SCNNode()
        
        guard let plantScene = SCNScene(named: "Dandelion3.scn") else {
            return nil
        }
        
        let node = SCNNode()
        
        for childNode in plantScene.rootNode.childNodes {
            node.addChildNode(childNode)
        }
        
        node.position = SCNVector3(x: 0.0, y: 1.0, z: 0.0)
        node.scale = SCNVector3(x: 0.8, y: 0.8, z: 0.8)
        
        plantNode.addChildNode(node)
        
        return plantNode
    }
```
- 차후에 식물별 정원 배치 position 항목을 추가하고 `Main`과 연결하면서 세부 기능을 추가/개선하도록 하겠습니다.

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|정원 오브젝트|<img src = "https://github.com/DevTillDie/ForestTori/assets/97589973/caa27e64-2e3f-46a9-830d-525ba2992901" width ="250">|

<br>

## 🗒️ Review Point
```
엔딩 이후 정원 뷰를 어떻게 구현할지 모르겠지만, 
정원 오브젝트 씬을 불러오는 코드를 재사용할 가능성이 높아, 해당 스크립트만 따로 컴포넌트 폴더에 위치시켰는데 이게 맞는 걸까요?
제 결정에 스스로도 모호함이 남아있어서 이렇게 글을 남깁니다. 🤔
```
