### PR TITLE
feat: make MainView ProgressBar

### DIFF
--- a/ForestTori/ForestTori.xcodeproj/project.pbxproj
+++ b/ForestTori/ForestTori.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		0E1AE71D2B80B9B2001C9A30 /* SummerCharacter.tsv in Resources */ = {isa = PBXBuildFile; fileRef = 0E1AE7192B80B9B1001C9A30 /* SummerCharacter.tsv */; };
 		0E1AE71E2B80B9B2001C9A30 /* SpringCharacter.tsv in Resources */ = {isa = PBXBuildFile; fileRef = 0E1AE71A2B80B9B2001C9A30 /* SpringCharacter.tsv */; };
 		0E1AE71F2B80B9B2001C9A30 /* AutumnCharacter.tsv in Resources */ = {isa = PBXBuildFile; fileRef = 0E1AE71B2B80B9B2001C9A30 /* AutumnCharacter.tsv */; };
+		0E4AB2282BC90A4C00ADB623 /* ProgressStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4AB2272BC90A4C00ADB623 /* ProgressStyle.swift */; };
 		0E58AB822B85BF5C00EB8C78 /* SelectPlantView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E58AB812B85BF5C00EB8C78 /* SelectPlantView.swift */; };
 		0E58AB842B8CAD1C00EB8C78 /* PlantCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E58AB832B8CAD1C00EB8C78 /* PlantCardView.swift */; };
 		0E58AB8F2B8E05AA00EB8C78 /* CompleteMissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E58AB8E2B8E05AA00EB8C78 /* CompleteMissionView.swift */; };
@@ -110,6 +111,7 @@
 		0E1AE7192B80B9B1001C9A30 /* SummerCharacter.tsv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SummerCharacter.tsv; sourceTree = "<group>"; };
 		0E1AE71A2B80B9B2001C9A30 /* SpringCharacter.tsv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SpringCharacter.tsv; sourceTree = "<group>"; };
 		0E1AE71B2B80B9B2001C9A30 /* AutumnCharacter.tsv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = AutumnCharacter.tsv; sourceTree = "<group>"; };
+		0E4AB2272BC90A4C00ADB623 /* ProgressStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressStyle.swift; sourceTree = "<group>"; };
 		0E58AB812B85BF5C00EB8C78 /* SelectPlantView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectPlantView.swift; sourceTree = "<group>"; };
 		0E58AB832B8CAD1C00EB8C78 /* PlantCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlantCardView.swift; sourceTree = "<group>"; };
 		0E58AB8E2B8E05AA00EB8C78 /* CompleteMissionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteMissionView.swift; sourceTree = "<group>"; };
@@ -312,6 +314,7 @@
 			children = (
 				5BA395822B8235D40019A545 /* Buttons */,
 				5B9152A92B8440300068418F /* TextBoxes */,
+				0E4AB2272BC90A4C00ADB623 /* ProgressStyle.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -768,6 +771,7 @@
 				5B68A4372B845E200004E89A /* View+.swift in Sources */,
 				5BA395842B82495B0019A545 /* OnboardingNamingView.swift in Sources */,
 				5BA885842B90698900041393 /* EndingView.swift in Sources */,
+				0E4AB2282BC90A4C00ADB623 /* ProgressStyle.swift in Sources */,
 				5B68A4262B8454790004E89A /* ServieStateView.swift in Sources */,
 				5BA3957F2B8235AF0019A545 /* OnboardingSkipButton.swift in Sources */,
 				0E58AB842B8CAD1C00EB8C78 /* PlantCardView.swift in Sources */,

--- a/ForestTori/ForestTori/Source/Utils/Component/ProgressStyle.swift
+++ b/ForestTori/ForestTori/Source/Utils/Component/ProgressStyle.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ProgressStyle: ProgressViewStyle {
     let width: Double
     let color: Color
+    let text: String
     
     func makeBody(configuration: Configuration) -> some View {
         let progress = configuration.fractionCompleted ?? 0.0
@@ -31,7 +32,7 @@ struct ProgressStyle: ProgressViewStyle {
                     .stroke(.white, lineWidth: 2)
                 
                 VStack {
-                    Text("식물")
+                    Text(text)
                         .font(.titleS)
                     Text("\(Int(progress*100))%")
                         .font(.titleL)

--- a/ForestTori/ForestTori/Source/Utils/Component/ProgressStyle.swift
+++ b/ForestTori/ForestTori/Source/Utils/Component/ProgressStyle.swift
@@ -16,8 +16,13 @@ struct ProgressStyle: ProgressViewStyle {
         let progress = configuration.fractionCompleted ?? 0.0
         
         ZStack(alignment: .leading) {
+            RoundedRectangle(cornerRadius: 45)
+                .fill(.clear)
+                .stroke(.white, lineWidth: 5)
+            
             Rectangle()
                 .fill(.clear)
+            
             Rectangle()
                 .fill(color)
                 .frame(width: width * progress)
@@ -27,19 +32,13 @@ struct ProgressStyle: ProgressViewStyle {
             RoundedRectangle(cornerRadius: 45)
         }
         .overlay {
-            ZStack {
-                RoundedRectangle(cornerRadius: 45)
-                    .fill(.clear)
-                    .stroke(.white, lineWidth: 2)
-                
-                VStack {
-                    Text(text)
-                        .font(.titleS)
-                    Text("\(Int(progress*100))%")
-                        .font(.titleL)
-                }
-                .foregroundStyle(.white)
+            VStack {
+                Text(text)
+                    .font(.titleS)
+                Text("\(Int(progress*100))%")
+                    .font(.titleL)
             }
+            .foregroundStyle(.white)
         }
     }
 }

--- a/ForestTori/ForestTori/Source/Utils/Component/ProgressStyle.swift
+++ b/ForestTori/ForestTori/Source/Utils/Component/ProgressStyle.swift
@@ -21,6 +21,7 @@ struct ProgressStyle: ProgressViewStyle {
             Rectangle()
                 .fill(color)
                 .frame(width: width * progress)
+                .animation(.easeInOut(duration: 0.5), value: progress)
         }
         .mask {
             RoundedRectangle(cornerRadius: 45)

--- a/ForestTori/ForestTori/Source/Utils/Component/ProgressStyle.swift
+++ b/ForestTori/ForestTori/Source/Utils/Component/ProgressStyle.swift
@@ -1,0 +1,43 @@
+//
+//  ProgressStyle.swift
+//  ForestTori
+//
+//  Created by hyebin on 4/12/24.
+//
+
+import SwiftUI
+
+struct ProgressStyle: ProgressViewStyle {
+    let width: Double
+    let color: Color
+    
+    func makeBody(configuration: Configuration) -> some View {
+        let progress = configuration.fractionCompleted ?? 0.0
+        
+        ZStack(alignment: .leading) {
+            Rectangle()
+                .fill(.clear)
+            Rectangle()
+                .fill(color)
+                .frame(width: width * progress)
+        }
+        .mask {
+            RoundedRectangle(cornerRadius: 45)
+        }
+        .overlay {
+            ZStack {
+                RoundedRectangle(cornerRadius: 45)
+                    .fill(.clear)
+                    .stroke(.white, lineWidth: 2)
+                
+                VStack {
+                    Text("식물")
+                        .font(.titleS)
+                    Text("\(Int(progress*100))%")
+                        .font(.titleL)
+                }
+                .foregroundStyle(.white)
+            }
+        }
+    }
+}

--- a/ForestTori/ForestTori/Source/View/Main/MainView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/MainView.swift
@@ -87,7 +87,7 @@ extension MainView {
                 .progressViewStyle(
                     ProgressStyle(
                         width: 119,
-                        color: .brown.opacity(0.7),
+                        color: .brown.opacity(0.8),
                         text: viewModel.plantName
                     )
                 )

--- a/ForestTori/ForestTori/Source/View/Main/MainView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/MainView.swift
@@ -13,7 +13,6 @@ struct MainView: View {
     
     @State private var selectedTab = 0
     @State private var isShowSelectPlantView = false
-    @State private var progressValue = 50.0
     
     var body: some View {
         ZStack {
@@ -83,10 +82,14 @@ extension MainView {
             
             Spacer()
             
-            ProgressView(value: progressValue, total: 100)
+            ProgressView(value: viewModel.progressValue, total: 100)
                 .frame(width: 119, height: 50)
                 .progressViewStyle(
-                    ProgressStyle(width: 119, color: .brown.opacity(0.7))
+                    ProgressStyle(
+                        width: 119,
+                        color: .brown.opacity(0.7),
+                        text: viewModel.plantName
+                    )
                 )
         }
         .padding(.horizontal, 20)

--- a/ForestTori/ForestTori/Source/View/Main/MainView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/MainView.swift
@@ -13,6 +13,7 @@ struct MainView: View {
     
     @State private var selectedTab = 0
     @State private var isShowSelectPlantView = false
+    @State private var progressValue = 50.0
     
     var body: some View {
         ZStack {
@@ -82,7 +83,11 @@ extension MainView {
             
             Spacer()
             
-            Image("PotProgress1")
+            ProgressView(value: progressValue, total: 100)
+                .frame(width: 119, height: 50)
+                .progressViewStyle(
+                    ProgressStyle(width: 119, color: .brown.opacity(0.7))
+                )
         }
         .padding(.horizontal, 20)
         .padding(.top, 69)

--- a/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
@@ -26,6 +26,9 @@ class MainViewModel: ObservableObject {
     @Published var isDisableDoneButton = false
     @Published var isCompleteMission = false
     
+    @Published var progressValue: Float = 0.0
+    @Published var plantName = ""
+    
     private var plant: Plant?
     private var missionDay = 0
     private var dialogues = [Dialogue]()
@@ -37,10 +40,12 @@ class MainViewModel: ObservableObject {
         
         if let plant = plant {
             getDialogue(plant.characterFileName)
-            isShowAddButton = false
-            isShowDialogueBox = true
             plant3DFileName = plant.character3DFiles[missionDay]
             plantWidth = 350
+            plantName = plant.characterName
+            
+            isShowAddButton = false
+            isShowDialogueBox = true
             
             dialogueText = dialogues[currentDialogueIndex].lines[currentLineIndex]
             missionText = plant.missions[missionDay].content
@@ -52,6 +57,8 @@ class MainViewModel: ObservableObject {
         plant3DFileName = "Emptypot.scn"
         missionDay = 0
         plantWidth = 200
+        progressValue = 0.0
+        plantName = ""
         
         dialogueText = ""
         missionText = ""
@@ -86,6 +93,7 @@ class MainViewModel: ObservableObject {
     func completMission() {
         currentDialogueIndex += 1
         currentLineIndex = 0
+        progressValue = (Float(missionDay+1)/Float(plant?.totalDay ?? 0)) * 100
         
         isShowDialogueBox = true
         isDisableDoneButton = true


### PR DESCRIPTION
## 📌 Summary
<!-- 이슈 번호
     이슈가 없다면 이 작업을 하게 된 이유 
     작업 내용 요약 -->
- resolve: #42 

<br>

## ✨ Description
- ProgressBar를 custom 하기 위해 `ProgressViewStyle` type의 struct를 생성했습니다.
- `ProgressStyle`은 이후 Garden에서도 사용하기 위해 `Component`에 위치 시켰습니다.
```swift
struct ProgressStyle: ProgressViewStyle {
    let width: Double
    let color: Color
    let text: String
    
    func makeBody(configuration: Configuration) -> some View {
        let progress = configuration.fractionCompleted ?? 0.0
        
        ZStack(alignment: .leading) {
            RoundedRectangle(cornerRadius: 45)
                .fill(.clear)
                .stroke(.white, lineWidth: 5)
            
            Rectangle()
                .fill(.clear)
            
            Rectangle()
                .fill(color)
                .frame(width: width * progress)
                .animation(.easeInOut(duration: 0.5), value: progress)
        }
        .mask {
            RoundedRectangle(cornerRadius: 45)
        }
        .overlay {
            VStack {
                Text(text)
                    .font(.titleS)
                Text("\(Int(progress*100))%")
                    .font(.titleL)
            }
            .foregroundStyle(.white)
        }
    }
}

```

- 테두리를 나타내기 위한 `RoundedRectangle`과 2개의 Rectangle을 ZStack으로 쌓은 후 RoundedRectangle 모양으로 잘라줍니다.
    -  두 번째 Rectangle은 `width*progress`로 진행률에 따라 크기가 달라집니다.
- Text를 나타내기 위해 overlay로 progress bar 위에 쌓아줍니다.

- MainView에서 ProgressView를 만들고 ProgressStyle을 적용합니다
```swift
ProgressView(value: viewModel.progressValue, total: 100)
      .frame(width: 119, height: 50)
      .progressViewStyle(
          ProgressStyle(
              width: 119,
              color: .brown.opacity(0.7),
              text: viewModel.plantName
          )
      )
```

- 진행률은 MainViewModel에서 계산합니다.
- 미션 완료 버튼을 눌러 `completMission()` 이 호출될 때 연산을 수행합니다.
```swift
func completMission() {
...
    progressValue = (Float(missionDay+1)/Float(plant?.totalDay ?? 0)) * 100
...
}
```
<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/DevTillDie/ForestTori/assets/55949986/6ec7b38d-75bd-4830-ab06-f4dddabbbffc" width ="250">|
<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
원래는 테두리를 나타내는 RoundedRectangle 위에 진행률을 나타내는 RoundedRectangle을 overlay 하려고 했습니다.
하지만 그렇게 하면 피그마처럼 진행률의 오른쪽이 직선으로 나오지 않아 Rectangle을 RoundedRectangle로 mask 하는 방법으로 구현하였습니다. 
제가 생각했을 때 최선의 방법이였는데 혹시 더 좋은 방법 있으시면 말씀해주세요!!
```
