### PR TITLE
feat: add ar view

### DIFF
--- a/ForestTori/ForestTori.xcodeproj/project.pbxproj
+++ b/ForestTori/ForestTori.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		5BA931192B6260CC00F48AF1 /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA931182B6260CC00F48AF1 /* DataManager.swift */; };
 		5BABC2C92B899D8B00C74E3C /* GardenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BABC2C82B899D8B00C74E3C /* GardenView.swift */; };
 		5BBABDE12BCD180A00F51288 /* CameraPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BBABDE02BCD180A00F51288 /* CameraPreview.swift */; };
+		5BBABDE32BCD716800F51288 /* GardenARViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BBABDE22BCD716800F51288 /* GardenARViewModel.swift */; };
 		5BDA85472BCC156400C5C67C /* GardenARView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDA85462BCC156400C5C67C /* GardenARView.swift */; };
 		5BE2F6302BC03AF90049A988 /* GardenScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE2F62F2BC03AF90049A988 /* GardenScene.swift */; };
 /* End PBXBuildFile section */
@@ -197,6 +198,7 @@
 		5BA931182B6260CC00F48AF1 /* DataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
 		5BABC2C82B899D8B00C74E3C /* GardenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GardenView.swift; sourceTree = "<group>"; };
 		5BBABDE02BCD180A00F51288 /* CameraPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreview.swift; sourceTree = "<group>"; };
+		5BBABDE22BCD716800F51288 /* GardenARViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GardenARViewModel.swift; sourceTree = "<group>"; };
 		5BDA85462BCC156400C5C67C /* GardenARView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GardenARView.swift; sourceTree = "<group>"; };
 		5BE2F62F2BC03AF90049A988 /* GardenScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GardenScene.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -517,6 +519,7 @@
 				0E1AE7102B80A77A001C9A30 /* MainViewModel.swift */,
 				5BA395632B7E4A230019A545 /* OnboardingViewModel.swift */,
 				5B72DDC72B91BA8B002EA734 /* EndingViewModel.swift */,
+				5BBABDE22BCD716800F51288 /* GardenARViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -798,6 +801,7 @@
 				5BE2F6302BC03AF90049A988 /* GardenScene.swift in Sources */,
 				5BA931132B62603200F48AF1 /* Plant.swift in Sources */,
 				0E1AE7052B7E18AF001C9A30 /* PlantPotView.swift in Sources */,
+				5BBABDE32BCD716800F51288 /* GardenARViewModel.swift in Sources */,
 				5BA395862B824D950019A545 /* NameSettingView.swift in Sources */,
 				0EF5FE962B4FC02100D64E5E /* ForestToriApp.swift in Sources */,
 				5B72DDC82B91BA8B002EA734 /* EndingViewModel.swift in Sources */,

--- a/ForestTori/ForestTori.xcodeproj/project.pbxproj
+++ b/ForestTori/ForestTori.xcodeproj/project.pbxproj
@@ -98,6 +98,8 @@
 		5BA931172B62605D00F48AF1 /* Mission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA931162B62605D00F48AF1 /* Mission.swift */; };
 		5BA931192B6260CC00F48AF1 /* DataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA931182B6260CC00F48AF1 /* DataManager.swift */; };
 		5BABC2C92B899D8B00C74E3C /* GardenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BABC2C82B899D8B00C74E3C /* GardenView.swift */; };
+		5BBABDE12BCD180A00F51288 /* CameraPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BBABDE02BCD180A00F51288 /* CameraPreview.swift */; };
+		5BDA85472BCC156400C5C67C /* GardenARView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDA85462BCC156400C5C67C /* GardenARView.swift */; };
 		5BE2F6302BC03AF90049A988 /* GardenScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE2F62F2BC03AF90049A988 /* GardenScene.swift */; };
 /* End PBXBuildFile section */
 
@@ -194,6 +196,8 @@
 		5BA931162B62605D00F48AF1 /* Mission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mission.swift; sourceTree = "<group>"; };
 		5BA931182B6260CC00F48AF1 /* DataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataManager.swift; sourceTree = "<group>"; };
 		5BABC2C82B899D8B00C74E3C /* GardenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GardenView.swift; sourceTree = "<group>"; };
+		5BBABDE02BCD180A00F51288 /* CameraPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreview.swift; sourceTree = "<group>"; };
+		5BDA85462BCC156400C5C67C /* GardenARView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GardenARView.swift; sourceTree = "<group>"; };
 		5BE2F62F2BC03AF90049A988 /* GardenScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GardenScene.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -557,6 +561,8 @@
 			isa = PBXGroup;
 			children = (
 				5BABC2C82B899D8B00C74E3C /* GardenView.swift */,
+				5BDA85462BCC156400C5C67C /* GardenARView.swift */,
+				5BBABDE02BCD180A00F51288 /* CameraPreview.swift */,
 			);
 			path = Garden;
 			sourceTree = "<group>";
@@ -783,6 +789,7 @@
 				5BA395842B82495B0019A545 /* OnboardingNamingView.swift in Sources */,
 				5BA885842B90698900041393 /* EndingView.swift in Sources */,
 				0E4AB2282BC90A4C00ADB623 /* ProgressStyle.swift in Sources */,
+				5BBABDE12BCD180A00F51288 /* CameraPreview.swift in Sources */,
 				5B68A4262B8454790004E89A /* ServieStateView.swift in Sources */,
 				5BA3957F2B8235AF0019A545 /* OnboardingSkipButton.swift in Sources */,
 				0E58AB842B8CAD1C00EB8C78 /* PlantCardView.swift in Sources */,
@@ -805,6 +812,7 @@
 				5BA395642B7E4A230019A545 /* OnboardingViewModel.swift in Sources */,
 				0E58AB8F2B8E05AA00EB8C78 /* CompleteMissionView.swift in Sources */,
 				5BA931112B62602200F48AF1 /* User.swift in Sources */,
+				5BDA85472BCC156400C5C67C /* GardenARView.swift in Sources */,
 				0E1AE7112B80A77A001C9A30 /* MainViewModel.swift in Sources */,
 				5BA395712B7F84410019A545 /* Onboarding.swift in Sources */,
 				5BA3955C2B7E359F0019A545 /* OnboardingView.swift in Sources */,
@@ -942,11 +950,13 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ForestTori/Preview Content\"";
-				DEVELOPMENT_TEAM = HQS8MXQ7B5;
+				DEVELOPMENT_TEAM = 5Z238234D5;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ForestTori/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "ForestTori uses camera";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "$(PRODUCT_NAME) uses photo library";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -972,11 +982,13 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"ForestTori/Preview Content\"";
-				DEVELOPMENT_TEAM = HQS8MXQ7B5;
+				DEVELOPMENT_TEAM = 5Z238234D5;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ForestTori/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "ForestTori uses camera";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "$(PRODUCT_NAME) uses photo library";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/ForestTori/ForestTori/Source/Utils/Component/Scenes/GardenScene.swift
+++ b/ForestTori/ForestTori/Source/Utils/Component/Scenes/GardenScene.swift
@@ -14,7 +14,7 @@ struct GardenScene: UIViewRepresentable {
     
     private let gardenObject = "Gardenground.scn"
     private let lightNode = SCNNode()
-    private let sceneView = SCNView()
+    let sceneView = SCNView()
     
     func makeUIView(context: Context) -> some UIView {
         setSceneView()

--- a/ForestTori/ForestTori/Source/View/Garden/CameraPreview.swift
+++ b/ForestTori/ForestTori/Source/View/Garden/CameraPreview.swift
@@ -1,0 +1,27 @@
+//
+//  CameraPreview.swift
+//  ForestTori
+//
+//  Created by Nayeon Kim on 4/15/24.
+//
+
+import SwiftUI
+
+import ARKit
+import RealityKit
+
+struct CameraPreview: UIViewRepresentable {
+    func makeUIView(context: Context) -> ARView {
+            let view = ARView()
+            let session = view.session
+            let config = ARWorldTrackingConfiguration()
+            config.isLightEstimationEnabled = true
+
+            config.planeDetection = [.horizontal]
+            session.run(config)
+        
+            return view
+        }
+    
+    func updateUIView(_ uiView: ARView, context: Context) { }
+}

--- a/ForestTori/ForestTori/Source/View/Garden/GardenARView.swift
+++ b/ForestTori/ForestTori/Source/View/Garden/GardenARView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct GardenARView: View {
     @Environment(\.presentationMode) var presentationMode
+    @StateObject var gardenARViewModel = GardenARViewModel()
     
     private var backButtonLabel = "돌아가기"
     private var backButtonImage = "chevron.backward"
@@ -21,13 +22,15 @@ struct GardenARView: View {
             VStack {
                 Spacer()
                 
-                cameraButtomBar
+                cameraBottomBar
             }
         }
         .ignoresSafeArea()
         .navigationBarBackButtonHidden(true)
     }
 }
+
+// MARK: - ARView
 
 extension GardenARView {
     @ViewBuilder private var ARView: some View {
@@ -36,14 +39,23 @@ extension GardenARView {
             
             CameraPreview()
             
-            GardenScene()
-                .scaledToFit()
+            VStack {
+                Spacer()
+                
+                GardenScene()
+                    .scaledToFit()
+                
+                Spacer()
+                Spacer()
+            }
         }
     }
 }
 
+// MARK: - cameraBottomBar
+
 extension GardenARView {
-    @ViewBuilder private var cameraButtomBar: some View {
+    @ViewBuilder private var cameraBottomBar: some View {
         ZStack {
             Button {
                 presentationMode.wrappedValue.dismiss()
@@ -60,7 +72,7 @@ extension GardenARView {
             }
             
             Button {
-                if let image = captureScreen() {
+                if let image = gardenARViewModel.captureScreen() {
                     UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
                 }
             } label: {
@@ -74,22 +86,6 @@ extension GardenARView {
             }
         }
         .background(.black)
-    }
-}
-
-extension GardenARView {
-    func captureScreen() -> UIImage? {
-        let frame = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height - 200)
-        
-        guard let window = UIApplication.shared.windows.first(where: { $0.isKeyWindow }) else { return nil }
-        
-        UIGraphicsBeginImageContextWithOptions(frame.size, false, 0.0)
-        defer { UIGraphicsEndImageContext() }
-        
-        window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
-        let capturedImage = UIGraphicsGetImageFromCurrentImageContext()
-        
-        return capturedImage
     }
 }
 

--- a/ForestTori/ForestTori/Source/View/Garden/GardenARView.swift
+++ b/ForestTori/ForestTori/Source/View/Garden/GardenARView.swift
@@ -1,0 +1,98 @@
+//
+//  ARView.swift
+//  ForestTori
+//
+//  Created by Nayeon Kim on 4/14/24.
+//
+
+import SwiftUI
+
+struct GardenARView: View {
+    @Environment(\.presentationMode) var presentationMode
+    
+    private var backButtonLabel = "돌아가기"
+    private var backButtonImage = "chevron.backward"
+    private var cameraButtomImage = "button.programmable"
+    
+    var body: some View {
+        ZStack {
+            ARView
+            
+            VStack {
+                Spacer()
+                
+                cameraButtomBar
+            }
+        }
+        .ignoresSafeArea()
+        .navigationBarBackButtonHidden(true)
+    }
+}
+
+extension GardenARView {
+    @ViewBuilder private var ARView: some View {
+        ZStack {
+            Color.black
+            
+            CameraPreview()
+            
+            GardenScene()
+                .scaledToFit()
+        }
+    }
+}
+
+extension GardenARView {
+    @ViewBuilder private var cameraButtomBar: some View {
+        ZStack {
+            Button {
+                presentationMode.wrappedValue.dismiss()
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: backButtonImage)
+                    Text(backButtonLabel)
+                    
+                    Spacer()
+                }
+                .foregroundColor(.white)
+                .font(.subtitleM)
+                .padding(.horizontal, 30)
+            }
+            
+            Button {
+                if let image = captureScreen() {
+                    UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
+                }
+            } label: {
+                ZStack {
+                    Image(systemName: cameraButtomImage)
+                        .resizable()
+                        .foregroundColor(.white)
+                        .frame(width: 70, height: 70)
+                        .padding(.vertical, 36)
+                }
+            }
+        }
+        .background(.black)
+    }
+}
+
+extension GardenARView {
+    func captureScreen() -> UIImage? {
+        let frame = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height - 200)
+        
+        guard let window = UIApplication.shared.windows.first(where: { $0.isKeyWindow }) else { return nil }
+        
+        UIGraphicsBeginImageContextWithOptions(frame.size, false, 0.0)
+        defer { UIGraphicsEndImageContext() }
+        
+        window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+        let capturedImage = UIGraphicsGetImageFromCurrentImageContext()
+        
+        return capturedImage
+    }
+}
+
+#Preview {
+    GardenARView()
+}

--- a/ForestTori/ForestTori/Source/View/Garden/GardenView.swift
+++ b/ForestTori/ForestTori/Source/View/Garden/GardenView.swift
@@ -44,6 +44,7 @@ struct GardenView: View {
                 }
             }
             .ignoresSafeArea()
+            .navigationBarBackButtonHidden(true)
         }
     }
 }
@@ -101,9 +102,7 @@ extension GardenView {
 
 extension GardenView {
     @ViewBuilder private var ARButton: some View {
-        Button {
-            // action
-        } label: {
+        NavigationLink(destination: GardenARView()) {
             Image(.arButton)
                 .resizable()
                 .scaledToFit()

--- a/ForestTori/ForestTori/Source/ViewModel/GardenARViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/GardenARViewModel.swift
@@ -1,0 +1,24 @@
+//
+//  GardenARViewModel.swift
+//  ForestTori
+//
+//  Created by Nayeon Kim on 4/15/24.
+//
+
+import SwiftUI
+
+class GardenARViewModel: ObservableObject {
+    func captureScreen() -> UIImage? {
+        let frame = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height - 200)
+        
+        guard let window = UIApplication.shared.windows.first(where: { $0.isKeyWindow }) else { return nil }
+        
+        UIGraphicsBeginImageContextWithOptions(frame.size, false, 0.0)
+        defer { UIGraphicsEndImageContext() }
+        
+        window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+        let capturedImage = UIGraphicsGetImageFromCurrentImageContext()
+        
+        return capturedImage
+    }
+}

--- a/ForestTori/ForestTori/Source/ViewModel/OnboardingViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/OnboardingViewModel.swift
@@ -152,12 +152,12 @@ extension OnboardingViewModel {
         ]
         
         let thirdText = [
-            OnboardingText(text: "여기 \(Text(userName).foregroundStyle(.greenPrimary))를 위해"),
+            OnboardingText(text: "여기 \(Text(userName).foregroundColor(.greenPrimary))를 위해"),
             OnboardingText(text: "신비한 화분을 줄게요."),
         ]
         
         let fourthText = [
-            OnboardingText(text: "이제부터 \(Text(userName).foregroundStyle(.greenPrimary))의"),
+            OnboardingText(text: "이제부터 \(Text(userName).foregroundColor(.greenPrimary))의"),
             OnboardingText(text: "마법 능력으로 식물을 잘 키워주세요."),
         ]
         


### PR DESCRIPTION
## 📌 Summary
- resolve: #46 

<br>

## ✨ Description
기존의 코드를 참고하여 새롭게 AR 뷰를 작성하였습니다. (기존 방식은 아래와 같습니다.)
- AR 뷰를 생성한 다음, 그 위에 오브젝트 파일을 가져오는 방식
- 화면을 캡처한 다음, 크롭하여 이미지를 저장하는 방식

먼저, ARKit과 RealityKit을 활용하여 ARView를 생성하였습니다.
```swift
struct CameraPreview: UIViewRepresentable {
    func makeUIView(context: Context) -> ARView {
            let view = ARView()
            let session = view.session
            let config = ARWorldTrackingConfiguration()
            config.isLightEstimationEnabled = true

            config.planeDetection = [.horizontal]
            session.run(config)
        
            return view
        }
    
    func updateUIView(_ uiView: ARView, context: Context) { }
}
```

그리고 정원 오브젝트 씬을 재사용하여 AR 뷰 위에 쌓았습니다.
```swift
extension GardenARView {
    @ViewBuilder private var ARView: some View {
        ZStack {
            Color.black
            
            CameraPreview()
            
            GardenScene()
                .scaledToFit()
        }
    }
}
```

이미지 저장은 기존 방식과 동일하게 화면 캡처 ➡️ 크롭 ➡️ 저장하는 방식을 채택하였습니다.
```swift
func captureScreen() -> UIImage? {
        let frame = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height - 200)
        
        guard let window = UIApplication.shared.windows.first(where: { $0.isKeyWindow }) else { return nil }
        
        UIGraphicsBeginImageContextWithOptions(frame.size, false, 0.0)
        defer { UIGraphicsEndImageContext() }
        
        window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
        let capturedImage = UIGraphicsGetImageFromCurrentImageContext()
        
        return capturedImage
    }
```
```swift
Button {
                if let image = gardenARViewModel.captureScreen() {
                    UIImageWriteToSavedPhotosAlbum(image, nil, nil, nil)
                }
            } label: {
                ZStack {
                    Image(systemName: cameraButtomImage)
                        .resizable()
                        .foregroundColor(.white)
                        .frame(width: 70, height: 70)
                        .padding(.vertical, 36)
                }
            }
```

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|AR 뷰|<image src = "https://github.com/DevTillDie/ForestTori/assets/97589973/4fd5fa05-6a74-499e-ae5e-32a0191cd00f" width ="250">|
|결과| <image src = "https://github.com/DevTillDie/ForestTori/assets/97589973/a7b2ff3b-4a88-4e70-9122-f2ed3a97f9e1" width ="250">

<br>

## 🗒️ Review Point
```
빠르고 간편하게 AR 뷰를 구현하는 방법에 대해 고민한 끝에 위의 방식을 채택하였습니다.
이 과정에서 다음 3가지 방식을 시도하였습니다.

1. 카메라 + 오브젝트 씬 재사용
2. AR + 오브젝트 씬 재사용
3. AR + AR뷰에 오브젝트 추가

3번, 1번, 2번 순으로 이상적이라고 생각하였으나, 구현을 시도하면서
2번 방식이 자원 낭비 최소화, 단순한 코드 및 구조라는 장점을 가지고 있다고 판단하였고, 
이에 최종적으로 2번 방식을 선택하였습니다.

그렇지만, 지극히 개인적인 판단이니 만약 이 부분에 대해 우려가 있으시거나 추가적인 확인이 필요하시다면
자유롭게 댓글 남겨주세요 :-)
```
