### PR TITLE
feat: add navigation between main view and garden view

### DIFF
--- a/ForestTori/ForestTori.xcodeproj/project.pbxproj
+++ b/ForestTori/ForestTori.xcodeproj/project.pbxproj
@@ -25,8 +25,6 @@
 		0E6AB0E52BC115A300B12610 /* SpringPlants.tsv in Resources */ = {isa = PBXBuildFile; fileRef = 0E6AB0E02BC115A300B12610 /* SpringPlants.tsv */; };
 		0E6AB0E62BC115A300B12610 /* AutumnPlants.tsv in Resources */ = {isa = PBXBuildFile; fileRef = 0E6AB0E12BC115A300B12610 /* AutumnPlants.tsv */; };
 		0E6AB0E72BC115A300B12610 /* WinterPlants.tsv in Resources */ = {isa = PBXBuildFile; fileRef = 0E6AB0E22BC115A300B12610 /* WinterPlants.tsv */; };
-		0E6AB0EA2BC12B8300B12610 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 0E6AB0E92BC12B8300B12610 /* Realm */; };
-		0E6AB0EC2BC12B8300B12610 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 0E6AB0EB2BC12B8300B12610 /* RealmSwift */; };
 		0EADEA582B7DEB0C0036D190 /* ground_maple.usdz in Resources */ = {isa = PBXBuildFile; fileRef = 0EADEA532B7DEB0C0036D190 /* ground_maple.usdz */; };
 		0EADEA592B7DEB0C0036D190 /* ground_cottontree.usdz in Resources */ = {isa = PBXBuildFile; fileRef = 0EADEA542B7DEB0C0036D190 /* ground_cottontree.usdz */; };
 		0EADEA5A2B7DEB0C0036D190 /* ground_none.usdz in Resources */ = {isa = PBXBuildFile; fileRef = 0EADEA552B7DEB0C0036D190 /* ground_none.usdz */; };
@@ -102,6 +100,8 @@
 		5BBABDE32BCD716800F51288 /* GardenARViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BBABDE22BCD716800F51288 /* GardenARViewModel.swift */; };
 		5BDA85472BCC156400C5C67C /* GardenARView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDA85462BCC156400C5C67C /* GardenARView.swift */; };
 		5BE2F6302BC03AF90049A988 /* GardenScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE2F62F2BC03AF90049A988 /* GardenScene.swift */; };
+		5BFED7C82BD65DF10051D91B /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 5BFED7C72BD65DF10051D91B /* Realm */; };
+		5BFED7CA2BD65DF10051D91B /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 5BFED7C92BD65DF10051D91B /* RealmSwift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -208,8 +208,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0E6AB0EC2BC12B8300B12610 /* RealmSwift in Frameworks */,
-				0E6AB0EA2BC12B8300B12610 /* Realm in Frameworks */,
+				5BFED7CA2BD65DF10051D91B /* RealmSwift in Frameworks */,
+				5BFED7C82BD65DF10051D91B /* Realm in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -648,8 +648,8 @@
 			);
 			name = ForestTori;
 			packageProductDependencies = (
-				0E6AB0E92BC12B8300B12610 /* Realm */,
-				0E6AB0EB2BC12B8300B12610 /* RealmSwift */,
+				5BFED7C72BD65DF10051D91B /* Realm */,
+				5BFED7C92BD65DF10051D91B /* RealmSwift */,
 			);
 			productName = ForestTori;
 			productReference = 0EF5FE922B4FC02100D64E5E /* ForestTori.app */;
@@ -1045,12 +1045,12 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		0E6AB0E92BC12B8300B12610 /* Realm */ = {
+		5BFED7C72BD65DF10051D91B /* Realm */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 0E6AB0E82BC12B8300B12610 /* XCRemoteSwiftPackageReference "realm-swift" */;
 			productName = Realm;
 		};
-		0E6AB0EB2BC12B8300B12610 /* RealmSwift */ = {
+		5BFED7C92BD65DF10051D91B /* RealmSwift */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 0E6AB0E82BC12B8300B12610 /* XCRemoteSwiftPackageReference "realm-swift" */;
 			productName = RealmSwift;

--- a/ForestTori/ForestTori/Resource/Chapters/AutumnPlants.tsv
+++ b/ForestTori/ForestTori/Resource/Chapters/AutumnPlants.tsv
@@ -1,6 +1,6 @@
-id	characterName	characterImage	characterDescription	mainQuest	missions	characterFileName	character3DFiles	totalDay
-1	단풍나무	PlantSelect_Autumn1	부끄럼이 많아 집에만 머무르던 단풍나무가 새로운 곳으로 여행을 떠나보려 해요. 단풍나무와 함께 여행을 준비해볼까요?	여행계획 세워보기	1:가보고 싶은 여행지 정하기|2:여행지에서 무엇을 하고싶은지 정하기|3:여행지까지 교통편 알아보기	AutumnCharacter	Maple1.scn|Maple2.scn|Maple3.scn	3
-2	???	PlantSelect_Autumn2	???	???				0
-3	???	PlantSelect_Autumn3	???	???				0
-4	???	PlantSelect_Autumn4	???	???				0
-5	???	PlantSelect_Autumn5	???	???				0
+id	characterName	characterImage	characterDescription	mainQuest	missions	characterFileName	character3DFiles	totalDay	garden3DFile	gardenPositionX	gardenPositionZ
+1	단풍나무	PlantSelect_Autumn1	부끄럼이 많아 집에만 머무르던 단풍나무가 새로운 곳으로 여행을 떠나보려 해요. 단풍나무와 함께 여행을 준비해볼까요?	여행계획 세워보기	1:가보고 싶은 여행지 정하기|2:여행지에서 무엇을 하고싶은지 정하기|3:여행지까지 교통편 알아보기	AutumnCharacter	Maple1.scn|Maple2.scn|Maple3.scn	3	Garden_MapleAnimation.scn	1.5	2
+2	???	PlantSelect_Autumn2	???	???				0			
+3	???	PlantSelect_Autumn3	???	???				0			
+4	???	PlantSelect_Autumn4	???	???				0			
+5	???	PlantSelect_Autumn5	???	???				0			

--- a/ForestTori/ForestTori/Resource/Chapters/SpringPlants.tsv
+++ b/ForestTori/ForestTori/Resource/Chapters/SpringPlants.tsv
@@ -1,6 +1,6 @@
-id	characterName	characterImage	characterDescription	mainQuest	missions	characterFileName	character3DFiles	totalDay
-1	민들레씨	PlantSelect_Spring1	겁이 많은 민들레씨들이 하늘로 날아가지 못하고 있어요. 용기를 낼 수 있게 매일 창문을 열어 민들레씨들을 도와줄래요?	창문 열고 30분 환기하기	1:창문 열고 30분 환기하기 1|2:창문 열고 30분 환기하기 2|3:창문 열고 30분 환기하기 3|4:창문 열고 30분 환기하기 4|5:창문 열고 30분 환기하기 5|6:창문 열고 30분 환기하기 6|7:창문 열고 30분 환기하기 7	SpringCharacter	Dandelion1.scn|Dandelion2.scn|Dandelion3.scn|Dandelion3.scn|Dandelion3.scn|Dandelion3.scn|Dandelion3.scn	7
-2	???	PlantSelect_Spring2	???	???				0
-3	???	PlantSelect_Spring3	???	???				0
-4	???	PlantSelect_Spring4	???	???				0
-5	???	PlantSelect_Spring5	???	???				0
+id	characterName	characterImage	characterDescription	mainQuest	missions	characterFileName	character3DFiles	totalDay	garden3DFile	gardenPositionX	gardenPositionZ
+1	민들레씨	PlantSelect_Spring1	겁이 많은 민들레씨들이 하늘로 날아가지 못하고 있어요. 용기를 낼 수 있게 매일 창문을 열어 민들레씨들을 도와줄래요?	창문 열고 30분 환기하기	1:창문 열고 30분 환기하기 1|2:창문 열고 30분 환기하기 2|3:창문 열고 30분 환기하기 3|4:창문 열고 30분 환기하기 4|5:창문 열고 30분 환기하기 5|6:창문 열고 30분 환기하기 6|7:창문 열고 30분 환기하기 7	SpringCharacter	Dandelion1.scn|Dandelion2.scn|Dandelion3.scn|Dandelion3.scn|Dandelion3.scn|Dandelion3.scn|Dandelion3.scn	7	Garden_DandelionAnimation.scn	-1.5	2
+2	???	PlantSelect_Spring2	???	???				0			
+3	???	PlantSelect_Spring3	???	???				0			
+4	???	PlantSelect_Spring4	???	???				0			
+5	???	PlantSelect_Spring5	???	???				0			

--- a/ForestTori/ForestTori/Resource/Chapters/SummerPlants.tsv
+++ b/ForestTori/ForestTori/Resource/Chapters/SummerPlants.tsv
@@ -1,6 +1,6 @@
-id	characterName	characterImage	characterDescription	mainQuest	missions	characterFileName	character3DFiles	totalDay
-1	선인장	PlantSelect_Summer1	꿈을 찾으려 먼 사막에서 온 작은 선인장 친구는 자신이 무엇을 좋아하는지 몰라 난처해하고 있어요. 함께 찾아볼까요?	\"내가 좋아하는 것이 뭘까?\" 기록해보기	1:\"내가 좋아하는 것이 뭘까?\" 기록해보기 1|2:\"내가 좋아하는 것이 뭘까?\" 기록해보기 2|3:\"내가 좋아하는 것이 뭘까?\" 기록해보기 3|4:\"내가 좋아하는 것이 뭘까?\" 기록해보기 4|5:\"내가 좋아하는 것이 뭘까?\" 기록해보기 5|6:\"내가 좋아하는 것이 뭘까?\" 기록해보기 6|7:\"내가 좋아하는 것이 뭘까?\" 기록해보기 7	SummerCharacter	Cactus1.scn|Cactus2.scn|Cactus3.scn|Cactus3.scn|Cactus3.scn|Cactus3.scn|Cactus3.scn	7
+id	characterName	characterImage	characterDescription	mainQuest	missions	characterFileName	character3DFiles	totalDay	garden3DFile	gardenPositionX	gardenPositionZ
+1	선인장	PlantSelect_Summer1	꿈을 찾으려 먼 사막에서 온 작은 선인장 친구는 자신이 무엇을 좋아하는지 몰라 난처해하고 있어요. 함께 찾아볼까요?	"\""내가 좋아하는 것이 뭘까?\"" 기록해보기"	"1:\""내가 좋아하는 것이 뭘까?\"" 기록해보기 1|2:\""내가 좋아하는 것이 뭘까?\"" 기록해보기 2|3:\""내가 좋아하는 것이 뭘까?\"" 기록해보기 3|4:\""내가 좋아하는 것이 뭘까?\"" 기록해보기 4|5:\""내가 좋아하는 것이 뭘까?\"" 기록해보기 5|6:\""내가 좋아하는 것이 뭘까?\"" 기록해보기 6|7:\""내가 좋아하는 것이 뭘까?\"" 기록해보기 7"	SummerCharacter	Cactus1.scn|Cactus2.scn|Cactus3.scn|Cactus3.scn|Cactus3.scn|Cactus3.scn|Cactus3.scn	7	Garden_CactusAnimation.scn	1.5	-2
 2	???	PlantSelect_Summer2	???	???				0
 3	???	PlantSelect_Summer3	???	???				0
-4	???	PlantSelect_Summer4	???	???				0
-5	???	PlantSelect_Summer5	???	???				0
+4	???	PlantSelect_Summer4	???	???				0			
+5	???	PlantSelect_Summer5	???	???				0			

--- a/ForestTori/ForestTori/Resource/Chapters/WinterPlants.tsv
+++ b/ForestTori/ForestTori/Resource/Chapters/WinterPlants.tsv
@@ -1,9 +1,9 @@
-id	characterName	characterImage	characterDescription	mainQuest	missions	characterFileName	character3DFiles	totalDay
-1	목화나무	PlantSelect_Winter1	이웃들의 도움 덕에 가을 불꽃으로부터 소중한 솜을 지킨 목화나무는, 자신도 도움이 필요한 사람들에게 힘이 되고자 해요. 함께 해볼까요?	봉사활동 해보기	1:1365 포털에서 봉사활동 신청하기|2:봉사활동 하기|3:봉사활동 인증서 확인하기	WinterCharacter	Cottontree1.scn|Cottontree2.scn|Cottontree3.scn	3
-2	???	PlantSelect_Winter2	???	???				0
-3	???	PlantSelect_Winter3	???	???				0
-4	???	PlantSelect_Winter4	???	???				0
-5	???	PlantSelect_Winter5	???	???				0
-6		PlantSelect_Winter6	???	???				0
-7		PlantSelect_Winter7	???	???				0
-8		PlantSelect_Winter8	???	???				0
+id	characterName	characterImage	characterDescription	mainQuest	missions	characterFileName	character3DFiles	totalDay	garden3DFile	gardenPositionX	gardenPositionZ
+1	목화나무	PlantSelect_Winter1	"이웃들의 도움 덕에 가을 불꽃으로부터 소중한 솜을 지킨 목화나무는, 자신도 도움이 필요한 사람들에게 힘이 되고자 해요. 함께 해볼까요?"	봉사활동 해보기	1:1365 포털에서 봉사활동 신청하기|2:봉사활동 하기|3:봉사활동 인증서 확인하기	WinterCharacter	Cottontree1.scn|Cottontree2.scn|Cottontree3.scn	3	Garden_CottontreeAnimation.scn	-1.5	-2
+2	???	PlantSelect_Winter2	???	???				0			
+3	???	PlantSelect_Winter3	???	???				0			
+4	???	PlantSelect_Winter4	???	???				0			
+5	???	PlantSelect_Winter5	???	???				0			
+6		PlantSelect_Winter6	???	???				0			
+7		PlantSelect_Winter7	???	???				0			
+8		PlantSelect_Winter8	???	???				0			

--- a/ForestTori/ForestTori/Source/Model/Plant.swift
+++ b/ForestTori/ForestTori/Source/Model/Plant.swift
@@ -18,6 +18,10 @@ import Foundation
 /// - characterFileName: 식물 Dialogue file 이름
 /// - character3DFiles: 식물 3D file 이름
 /// - totalDay: 식물의 성장 완료에 필요한 총 일수
+/// - garden3DFile: 정원 배치 식물 3D file 이름
+/// - gardenPositionX: 정원 배치 x position 값
+/// - gardenPositionY: 정원 배치 y position 값
+/// - gardenPositionZ: 정원 배치 z position 값
 struct Plant: Identifiable, Codable {
     var id: Int
     var characterName: String
@@ -28,4 +32,8 @@ struct Plant: Identifiable, Codable {
     var characterFileName: String
     var character3DFiles: [String]
     var totalDay: Int
+    var garden3DFile: String
+    var gardenPositionX: Float
+    var gardenPositionY: Float = 0.5
+    var gardenPositionZ: Float
 }

--- a/ForestTori/ForestTori/Source/Model/User.swift
+++ b/ForestTori/ForestTori/Source/Model/User.swift
@@ -5,14 +5,14 @@
 //  Created by Nayeon Kim on 1/25/24.
 //
 
-import Foundation
+import SwiftUI
 
 /// 사용자 정보
 ///
 /// - selectedPlant: 사용자가 선택한 식물
 /// - chapterProgress: 사용자가 현재 진행 중인 챕터 번호
 /// - completedPlants: 성장이 완료된 식물 목록
-struct User {
+struct User: Codable {
     var selectedPlant: Plant?
     var chapterProgress = 1
     var completedPlants: [Plant] = []

--- a/ForestTori/ForestTori/Source/Utils/Component/Scenes/GardenScene.swift
+++ b/ForestTori/ForestTori/Source/Utils/Component/Scenes/GardenScene.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import SceneKit
 
 struct GardenScene: UIViewRepresentable {
-    @StateObject var gameManager = GameManager()
+    @StateObject var gameManager: GameManager
     
     private let gardenObject = "Gardenground.scn"
     private let lightNode = SCNNode()

--- a/ForestTori/ForestTori/Source/Utils/Component/Scenes/GardenScene.swift
+++ b/ForestTori/ForestTori/Source/Utils/Component/Scenes/GardenScene.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import SceneKit
 
 struct GardenScene: UIViewRepresentable {
-    @EnvironmentObject var gameManager: GameManager
+    @StateObject var gameManager = GameManager()
     
     private let gardenObject = "Gardenground.scn"
     private let lightNode = SCNNode()
@@ -19,11 +19,12 @@ struct GardenScene: UIViewRepresentable {
     func makeUIView(context: Context) -> some UIView {
         setSceneView()
         
-        // TODO: gameManager 연결
-        guard let newNode = addNode() else {
-            return sceneView
+        for index in 0..<gameManager.user.completedPlants.count {
+            guard let newNode = addNode(index: index) else {
+                return sceneView
+            }
+            sceneView.scene?.rootNode.addChildNode(newNode)
         }
-        sceneView.scene?.rootNode.addChildNode(newNode)
         
         return sceneView
     }
@@ -69,12 +70,18 @@ extension GardenScene {
         }
     }
     
-    private func addNode() -> SCNNode? {
+    private func addNode(index: Int) -> SCNNode? {
         let plantNode = SCNNode()
         
-        guard let plantScene = SCNScene(named: "Dandelion3.scn") else {
+        let plant = gameManager.user.completedPlants[index]
+        
+        guard let plantScene = SCNScene(named: plant.garden3DFile) else {
             return nil
         }
+        
+        let plantPositionX = plant.gardenPositionX
+        let plantPositionY = plant.gardenPositionY
+        let plantPositionZ = plant.gardenPositionZ
         
         let node = SCNNode()
         
@@ -82,8 +89,8 @@ extension GardenScene {
             node.addChildNode(childNode)
         }
         
-        node.position = SCNVector3(x: 0.0, y: 1.0, z: 0.0)
-        node.scale = SCNVector3(x: 0.8, y: 0.8, z: 0.8)
+        node.position = SCNVector3(x: plantPositionX, y: plantPositionY, z: plantPositionZ)
+        node.scale = SCNVector3(x: 1.0, y: 1.0, z: 1.0)
         
         plantNode.addChildNode(node)
         

--- a/ForestTori/ForestTori/Source/Utils/Manager/DataManager.swift
+++ b/ForestTori/ForestTori/Source/Utils/Manager/DataManager.swift
@@ -15,7 +15,7 @@ class DataManager: ObservableObject {
     
     // UserDefaults에 데이터가 있다면 그 데이터를 읽어오고, 없다면 파일에서 읽어와 UserDefaults에 저장
     init() {
-        if let data = UserDefaults.standard.data(forKey: "chapterData"),
+        if let data = UserDefaults.standard.data(forKey: "_chaptersData"),
            let decodedChapters = try? JSONDecoder().decode([Chapter].self, from: data) {
             self.chapters = decodedChapters
         } else {
@@ -84,7 +84,7 @@ extension DataManager {
                         .map {$0.replacingOccurrences(of: "\\n", with: "\n")}
                         .map {$0.replacingOccurrences(of: "\r", with: "")}
                     
-                    if data.count >= 9 {
+                    if data.count >= 12 {
                         let id = Int(data[0]) ?? 0
                         let characterName = data[1]
                         let characterImage = data[2]
@@ -104,6 +104,9 @@ extension DataManager {
                         let characterFileName = data[6]
                         let character3DFiles = data[7].components(separatedBy: "|").map {String($0)}
                         let totalDay = Int(data[8]) ?? 0
+                        let garden3DFile = data[9]
+                        let gardenPositionX = Float(data[10]) ?? 0.0
+                        let gardenPositionZ = Float(data[11]) ?? 0.0
                         
                         plants.append(
                             Plant(
@@ -115,7 +118,10 @@ extension DataManager {
                                 missions: missions,
                                 characterFileName: characterFileName, 
                                 character3DFiles: character3DFiles,
-                                totalDay: totalDay
+                                totalDay: totalDay,
+                                garden3DFile: garden3DFile,
+                                gardenPositionX: gardenPositionX,
+                                gardenPositionZ: gardenPositionZ
                             )
                         )
                     }
@@ -135,7 +141,7 @@ extension DataManager {
     private func saveChapterDataToUserDefaults() {
         do {
             let encodedData = try JSONEncoder().encode(chapters)
-            UserDefaults.standard.set(encodedData, forKey: "chapterData")
+            UserDefaults.standard.set(encodedData, forKey: "_chaptersData")
         } catch {
             print("Error encoding chapters: \(error)")
         }

--- a/ForestTori/ForestTori/Source/Utils/Manager/GameManager.swift
+++ b/ForestTori/ForestTori/Source/Utils/Manager/GameManager.swift
@@ -5,12 +5,13 @@
 //  Created by Nayeon Kim on 2/6/24.
 //
 
-import Foundation
+import SwiftUI
 
 /// 게임 진행을 관리하는 클래스
 ///
 /// - user: 사용자 정보 모델
 /// - dataManager: 게임 데이터를 관리하는 클래스
+/// - isSelectPlant: 식물 선택 여부
 class GameManager: ObservableObject {
     @Published var user = User()
     @Published var chapter: Chapter
@@ -19,16 +20,31 @@ class GameManager: ObservableObject {
     private let dataManager = DataManager()
     
     init() {
-        chapter = dataManager.chapters[0]
+        // 진행 중인 정보를 유지하기 위해 UserDefault에 저장
+        if let userData = UserDefaults.standard.data(forKey: "_userData"),
+           let decodeData = try? JSONDecoder().decode(User.self, from: userData) {
+            self.user = decodeData
+        }
+        
+        if let chapterData = UserDefaults.standard.data(forKey: "_chapterData"),
+           let decodeData = try? JSONDecoder().decode(Chapter.self, from: chapterData) {
+            self.chapter = decodeData
+        } else {
+            chapter = dataManager.chapters[0]
+            saveChapterDataToUserDefaults()
+        }
     }
     
+    /// 새로운 게임 시작
     func startNewGame() {
         if let plant = user.selectedPlant {
             user.completedPlants.append(plant)
-            user.selectedPlant = nil
         }
         
+        user.selectedPlant = nil
         isSelectPlant = false
+        
+        saveUserDataToUserDefaults()
     }
     
     /// 식물 선택
@@ -37,19 +53,43 @@ class GameManager: ObservableObject {
     func selectPlant(plant: Plant) {
         user.selectedPlant = plant
         isSelectPlant = true
+        
+        saveUserDataToUserDefaults()
     }
     
     /// 미션 완료 레벨업 및 챕터 진행 체크
     ///
     /// 미션 완료 후 호출되어 사용자의 레벌업 및 챕터 진행 상태를 확인합니다
     func completeMission() {
-        // TODO: 레벨업 및 챕터 진행 체크 코드 추가
         user.chapterProgress += 1
         
         if user.chapterProgress == 5 {
             // TODO: 엔딩
+        } else {
+            chapter = dataManager.chapters[user.chapterProgress - 1]
         }
         
-        chapter = dataManager.chapters[user.chapterProgress-1]
+        saveUserDataToUserDefaults()
+        saveChapterDataToUserDefaults()
+    }
+    
+    /// 사용자 모델 데이터를 userDefaults에 저장
+    private func saveUserDataToUserDefaults() {
+        do {
+            let encodedData = try JSONEncoder().encode(user)
+            UserDefaults.standard.set(encodedData, forKey: "_userData")
+        } catch {
+            print("Error encoding user ata: \(error)")
+        }
+    }
+    
+    /// 챕터 모델 데이터를 userDefaults에 저장
+    private func saveChapterDataToUserDefaults() {
+        do {
+            let encodedData = try JSONEncoder().encode(chapter)
+            UserDefaults.standard.set(encodedData, forKey: "_chapterData")
+        } catch {
+            print("Error encoding chapter data: \(error)")
+        }
     }
 }

--- a/ForestTori/ForestTori/Source/Utils/Manager/GameManager.swift
+++ b/ForestTori/ForestTori/Source/Utils/Manager/GameManager.swift
@@ -35,7 +35,7 @@ class GameManager: ObservableObject {
         }
     }
     
-    /// 새로운 게임 시작
+    /// 새로운 스토리 시작
     func startNewGame() {
         if let plant = user.selectedPlant {
             user.completedPlants.append(plant)

--- a/ForestTori/ForestTori/Source/View/Garden/GardenView.swift
+++ b/ForestTori/ForestTori/Source/View/Garden/GardenView.swift
@@ -8,43 +8,50 @@
 import SwiftUI
 
 struct GardenView: View {
-    @StateObject var gameManager: GameManager
+    @StateObject var gameManager = GameManager()
+    
+    @State var showSummerMessage = true
+    
     private let noPlantCaption = "아직 다 키운 식물이 없어요."
+    private let summerMessage = "여름 하늘은 봄보다 더 높아져서 더 멀리까지 바라볼 수 있는 거 알아?"
     
     var body: some View {
         NavigationView {
             ZStack {
-                Image(.springBackground)
+                Image(gameManager.chapter.chatperBackgroundImage)
                     .resizable()
                     .scaledToFit()
                 
-                VStack(spacing: 40) {
-                    Spacer()
-                    Spacer()
-                    
-                    GardenScene()
-                        .scaledToFit()
-                    
-                    noPlantCaptionBox
-                        .hidden(gameManager.user.completedPlants.isEmpty)
+                VStack {
+                    gardenHeader
                     
                     Spacer()
+                    
+                    VStack(spacing: 0) {
+                        dialogueBox
+                            .hidden(gameManager.chapter.chapterId == 2 && showSummerMessage)
+                        
+                        GardenScene()
+                            .scaledToFit()
+                        
+                        noPlantCaptionBox
+                            .hidden(gameManager.user.completedPlants.isEmpty)
+                    }
+                    .padding(.top, 24)
+                    .padding(.bottom, 60)
+                    
                     Spacer()
-                }
-            }
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    toMainButton
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    totalProgressBar
-                }
-                ToolbarItem(placement: .bottomBar) {
+                    
                     ARButton
                 }
             }
             .ignoresSafeArea()
             .navigationBarBackButtonHidden(true)
+            .onAppear{
+                print(gameManager.chapter.chapterTitle)
+                print(gameManager.chapter.chatperBackgroundImage)
+                print(gameManager.user.chapterProgress)
+            }
         }
     }
 }
@@ -52,32 +59,69 @@ struct GardenView: View {
 // MARK: - toMainButton
 
 extension GardenView {
-    @ViewBuilder private var toMainButton: some View {
-        Button {
-            // action
-        } label: {
-            Image(.gardenButton)
+    @ViewBuilder private var gardenHeader: some View {
+        HStack {
+            NavigationLink(
+                destination: MainView().navigationBarBackButtonHidden(true)
+            ) {
+                Image(.gardenButton)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 45, height: 45)
+            }
+            
+            Spacer()
+            
+            // TODO: TotalProgressBar 수정
+            ZStack {
+                Image(.gardenProgressSpring3)
+                VStack {
+                    Text(gameManager.chapter.chapterTitle)
+                        .font(.titleS)
+                    Text("21%")
+                        .font(.titleL)
+                }
+                .foregroundColor(.white)
+                .shadow(color: .gray30, radius: 4.0)
+            }
         }
-        .padding(.top)
+        .padding(.horizontal, 20)
+        .padding(.top, 69)
+        .padding(.bottom, 8)
     }
 }
 
-// MARK: - totalProgressBar
+// MARK: - dialogueBox
 
 extension GardenView {
-    @ViewBuilder private var totalProgressBar: some View {
-        ZStack {
-            Image(.gardenProgressSpring3)
-            VStack {
-                Text("봄, 숲을 만나다")
-                    .font(.titleS)
-                Text("21%")
-                    .font(.titleL)
+    // TODO: 컴포넌트화
+    private var dialogueBox: some View {
+        Image("DialogFrame")
+            .resizable()
+            .scaledToFit()
+            .overlay(alignment: .top) {
+                ZStack(alignment: .topLeading) {
+                    Text(summerMessage)
+                        .font(.pretendard(size: 17.5, .regular))
+                        .foregroundStyle(Color.black)
+                        .multilineTextAlignment(.leading)
+                        .lineSpacing(1)
+                        .padding(.horizontal, 16)
+                    
+                    Image("DialogButton")
+                        .resizable()
+                        .frame(width: 16, height: 10)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+                        .padding(.bottom, 18)
+                        .padding(.trailing, 18)
+                }
+                .padding(.vertical, 12)
+                
             }
-            .foregroundColor(.white)
-            .shadow(color: .gray30, radius: 4.0)
-        }
-        .padding(.top)
+            .padding(.horizontal, 20)
+            .onTapGesture {
+                showSummerMessage = false
+            }
     }
 }
 
@@ -108,6 +152,7 @@ extension GardenView {
                 .scaledToFit()
                 .frame(maxWidth: 50.0, minHeight: 50.0)
         }
+        .padding(.bottom, 42)
     }
 }
 

--- a/ForestTori/ForestTori/Source/View/Main/CompleteMissionView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/CompleteMissionView.swift
@@ -45,11 +45,11 @@ struct CompleteMissionView: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 .padding(.horizontal, 23)
-              
+                
                 HStack(spacing: 16) {
-                    Button {
-                        
-                    } label: {
+                    NavigationLink(destination: GardenView()
+                        .navigationBarBackButtonHidden(true)
+                    ) {
                         Text("정원으로")
                             .font(.titleS)
                             .foregroundStyle(.white)

--- a/ForestTori/ForestTori/Source/View/Main/CompleteMissionView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/CompleteMissionView.swift
@@ -24,7 +24,7 @@ struct CompleteMissionView: View {
                 Text(gameManager.chapter.lastChapterEnding)
                     .font(.subtitleM)
                 
-                Image("ChapterThumbnail\(gameManager.user.chapterProgress)")
+                Image("ChapterThumbnail\( gameManager.user.chapterProgress)")
                     .resizable()
                     .scaledToFit()
                     .frame(height: 186)

--- a/ForestTori/ForestTori/Source/View/Main/MainView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/MainView.swift
@@ -15,52 +15,54 @@ struct MainView: View {
     @State private var isShowSelectPlantView = false
     
     var body: some View {
-        ZStack {
-            Image(gameManager.chapter.chatperBackgroundImage)
-                .resizable()
-                .scaledToFit()
-            
-            VStack {
-                mainHeader
+        NavigationView {
+            ZStack {
+                Image(gameManager.chapter.chatperBackgroundImage)
+                    .resizable()
+                    .scaledToFit()
                 
-                Spacer()
-                
-                PlantView(isShowSelectPlantView: $isShowSelectPlantView)
-                    .environmentObject(gameManager)
-                    .environmentObject(viewModel)
-                
-                customTabBar
-            }
-            
-            if isShowSelectPlantView {
-                Color.black.opacity(0.4)
-                
-                Text("식물 친구를 선택해주세요")
-                    .font(.titleM)
-                    .foregroundColor(.white)
-                    .padding(.top, 160)
-                    .frame(maxHeight: .infinity, alignment: .top)
+                VStack {
+                    mainHeader
                     
-                SelectPlantView(isShowSelectPlantView: $isShowSelectPlantView)
-                    .environmentObject(gameManager)
-            }
-            
-            if viewModel.isCompleteMission {
-                Color.black.opacity(0.4)
+                    Spacer()
+                    
+                    PlantView(isShowSelectPlantView: $isShowSelectPlantView)
+                        .environmentObject(gameManager)
+                        .environmentObject(viewModel)
+                    
+                    customTabBar
+                }
                 
-                CompleteMissionView()
-                    .environmentObject(gameManager)
-                    .onAppear {
-                        gameManager.completeMission()
-                    }
+                if isShowSelectPlantView {
+                    Color.black.opacity(0.4)
+                    
+                    Text("식물 친구를 선택해주세요")
+                        .font(.titleM)
+                        .foregroundColor(.white)
+                        .padding(.top, 160)
+                        .frame(maxHeight: .infinity, alignment: .top)
+                    
+                    SelectPlantView(isShowSelectPlantView: $isShowSelectPlantView)
+                        .environmentObject(gameManager)
+                }
+                
+                if viewModel.isCompleteMission {
+                    Color.black.opacity(0.4)
+                    
+                    CompleteMissionView()
+                        .environmentObject(gameManager)
+                        .onAppear {
+                            gameManager.completeMission()
+                        }
+                }
             }
-        }
-        .ignoresSafeArea()
-        .onChange(of: gameManager.isSelectPlant) {
-            if  gameManager.isSelectPlant {
-                viewModel.setNewPlant(plant: gameManager.user.selectedPlant)
-            } else {
-                viewModel.setEmptyPot()
+            .ignoresSafeArea()
+            .onChange(of: gameManager.isSelectPlant) {
+                if  gameManager.isSelectPlant {
+                    viewModel.setNewPlant(plant: gameManager.user.selectedPlant)
+                } else {
+                    viewModel.setEmptyPot()
+                }
             }
         }
     }
@@ -71,9 +73,9 @@ struct MainView: View {
 extension MainView {
     private var mainHeader: some View {
         HStack {
-            Button {
-                // TODO: Move to Garden
-            } label: {
+            NavigationLink(destination: GardenView()
+                .navigationBarBackButtonHidden(true)
+            ) {
                 Image("MainButton")
                     .resizable()
                     .scaledToFit()


### PR DESCRIPTION
## 📌 Summary
<!-- 이슈 번호
     이슈가 없다면 이 작업을 하게 된 이유 
     작업 내용 요약 -->
- resolve: #45 

<br>

## ✨ Description
<!-- 작업 내용 -->
- NavigationLink를 활용하여 Main View와 Garden View를 연결하였습니다.
- Main View를 기준으로 GardenView의 화면 레이아웃을 수정하였습니다.
   - 식물 오브젝트의 대화 상자를 추가하였습니다.
   - 대화 상자의 경우 Main View와 Garden View가 공동으로 사용하는 부분이라 추후에 컴포넌트화하여 사용하면 좋을 것 같습니다.
   ```swift
    private var dialogueBox: some View {
        Image("DialogFrame")
            .resizable()
            .scaledToFit()
            .overlay(alignment: .top) {
                ZStack(alignment: .topLeading) {
                    Text(summerMessage)
                        .font(.pretendard(size: 17.5, .regular))
                        .foregroundStyle(Color.black)
                        .multilineTextAlignment(.leading)
                        .lineSpacing(1)
                        .padding(.horizontal, 16)
                    
                    Image("DialogButton")
                        .resizable()
                        .frame(width: 16, height: 10)
                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
                        .padding(.bottom, 18)
                        .padding(.trailing, 18)
                }
                .padding(.vertical, 12)
                
            }
            .padding(.horizontal, 20)
            .onTapGesture {
                showSummerMessage = false
            }
    }
   ```
- Plant 모델과 각 계절별 식물 파일도 수정하였습니다.
```swift
/// 식물 정보
///
/// - id: 식물의 id
/// - characterName: 식물의 이름
/// - characterImage: 식물의 이미지
/// - characterDescription: 식물 소개
/// - mainQuest: 식물 메인 미션
/// - missions: 해당 식물의 미션 목록
/// - characterFileName: 식물 Dialogue file 이름
/// - character3DFiles: 식물 3D file 이름
/// - totalDay: 식물의 성장 완료에 필요한 총 일수
/// - garden3DFile: 정원 배치 식물 3D file 이름
/// - gardenPositionX: 정원 배치 x position 값
/// - gardenPositionY: 정원 배치 y position 값
/// - gardenPositionZ: 정원 배치 z position 값
struct Plant: Identifiable, Codable {
    var id: Int
    var characterName: String
    var characterImage: String
    var characterDescription: String
    var mainQuest: String
    var missions: [Mission]
    var characterFileName: String
    var character3DFiles: [String]
    var totalDay: Int
    var garden3DFile: String
    var gardenPositionX: Float
    var gardenPositionY: Float = 0.5
    var gardenPositionZ: Float
}
```
- 두 화면 간의 진행 상황을 공유하고 유지하기 위해 GameManager를 수정하였습니다.
   - `UserDefaults`를 활용하여 user 변수와 chapter 변수의 값이 유지되도록 하였습니다.
   ```swift
   @Published var user = User()
    @Published var chapter: Chapter
    @Published var isSelectPlant = false
    
    private let dataManager = DataManager()
    
    init() {
        // 진행 중인 정보를 유지하기 위해 UserDefault에 저장
        if let userData = UserDefaults.standard.data(forKey: "_userData"),
           let decodeData = try? JSONDecoder().decode(User.self, from: userData) {
            self.user = decodeData
        }
   ...
       /// 사용자 모델 데이터를 userDefaults에 저장
    private func saveUserDataToUserDefaults() {
        do {
            let encodedData = try JSONEncoder().encode(user)
            UserDefaults.standard.set(encodedData, forKey: "_userData")
        } catch {
            print("Error encoding user ata: \(error)")
        }
    }
    
    /// 챕터 모델 데이터를 userDefaults에 저장
    private func saveChapterDataToUserDefaults() {
        do {
            let encodedData = try JSONEncoder().encode(chapter)
            UserDefaults.standard.set(encodedData, forKey: "_chapterData")
        } catch {
            print("Error encoding chapter data: \(error)")
        }
    }

   ```
- 추가적으로 UserDefaults 키 이름의 일관성을 유지하고 지난 설정과 충돌을 막고자 `_(변수병)Data` 형식으로 맞춰두었습니다.4

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|메인-정원 이동|<img src = "https://github.com/DevTillDie/ForestTori/assets/97589973/c230014d-eda4-4cbc-99d1-589ec71f7a67" width ="250">|
|스토리 진행 연결|<img src = "https://github.com/DevTillDie/ForestTori/assets/97589973/4ebf2659-f083-4b45-ab00-3702cc319e2b" width ="250">|

<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
다음과 같은 작업을 추가적으로 진행해야 합니다.
1. 스토리 진행 중, 다른 화면으로 이동 후 Main View로 돌아오면 식물 성장 진행 상황이 유지되지 않는 것 해결 (빈 화분으로 초기화)
2. 여름 식물 파일에 "\" 지우기 (csv 파일에 사용되었던 코드가 아직 유지되어 있더라고요.)
```
