### PR TITLE
feat: integrate main and ending

### DIFF
--- a/ForestTori/ForestTori.xcodeproj/project.pbxproj
+++ b/ForestTori/ForestTori.xcodeproj/project.pbxproj
@@ -18,8 +18,6 @@
 		0E1AE71F2B80B9B2001C9A30 /* AutumnCharacter.tsv in Resources */ = {isa = PBXBuildFile; fileRef = 0E1AE71B2B80B9B2001C9A30 /* AutumnCharacter.tsv */; };
 		0E4AB2282BC90A4C00ADB623 /* ProgressStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4AB2272BC90A4C00ADB623 /* ProgressStyle.swift */; };
 		0E4AB22B2BCD3E7E00ADB623 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4AB22A2BCD3E7E00ADB623 /* HistoryView.swift */; };
-		0E4AB22E2BCD3EBE00ADB623 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 0E4AB22D2BCD3EBE00ADB623 /* Realm */; };
-		0E4AB2302BCD3EBE00ADB623 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 0E4AB22F2BCD3EBE00ADB623 /* RealmSwift */; };
 		0E4AB2322BCD66A400ADB623 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4AB2312BCD66A400ADB623 /* ImagePicker.swift */; };
 		0E4AB2342BCD6CE900ADB623 /* HistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4AB2332BCD6CE900ADB623 /* HistoryViewModel.swift */; };
 		0E4AB2362BCD70F400ADB623 /* RealmManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4AB2352BCD70F400ADB623 /* RealmManager.swift */; };
@@ -81,7 +79,7 @@
 		5B68A4342B845DDE0004E89A /* ModifierInitFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B68A4332B845DDE0004E89A /* ModifierInitFile.swift */; };
 		5B68A4352B845DFE0004E89A /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E1AE6FD2B7E185B001C9A30 /* Font+.swift */; };
 		5B68A4372B845E200004E89A /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B68A4362B845E200004E89A /* View+.swift */; };
-		5B72DDC82B91BA8B002EA734 /* EndingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B72DDC72B91BA8B002EA734 /* EndingViewModel.swift */; };
+		5B72DDC82B91BA8B002EA734 /* EpilogueViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B72DDC72B91BA8B002EA734 /* EpilogueViewModel.swift */; };
 		5B9152A82B84402C0068418F /* OnboardingTextBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9152A72B84402C0068418F /* OnboardingTextBox.swift */; };
 		5BA395442B7252C00019A545 /* GameManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA395432B7252C00019A545 /* GameManager.swift */; };
 		5BA3955C2B7E359F0019A545 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA3955B2B7E359F0019A545 /* OnboardingView.swift */; };
@@ -98,7 +96,7 @@
 		5BA395842B82495B0019A545 /* OnboardingNamingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA395832B82495B0019A545 /* OnboardingNamingView.swift */; };
 		5BA395862B824D950019A545 /* NameSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA395852B824D950019A545 /* NameSettingView.swift */; };
 		5BA395882B826CEA0019A545 /* OnboardingCompletionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA395872B826CEA0019A545 /* OnboardingCompletionView.swift */; };
-		5BA885842B90698900041393 /* EndingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA885832B90698900041393 /* EndingView.swift */; };
+		5BA885842B90698900041393 /* EpilogueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA885832B90698900041393 /* EpilogueView.swift */; };
 		5BA931112B62602200F48AF1 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA931102B62602200F48AF1 /* User.swift */; };
 		5BA931132B62603200F48AF1 /* Plant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA931122B62603200F48AF1 /* Plant.swift */; };
 		5BA931152B62604800F48AF1 /* Chapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA931142B62604800F48AF1 /* Chapter.swift */; };
@@ -109,8 +107,10 @@
 		5BBABDE32BCD716800F51288 /* GardenARViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BBABDE22BCD716800F51288 /* GardenARViewModel.swift */; };
 		5BDA85472BCC156400C5C67C /* GardenARView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDA85462BCC156400C5C67C /* GardenARView.swift */; };
 		5BE2F6302BC03AF90049A988 /* GardenScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE2F62F2BC03AF90049A988 /* GardenScene.swift */; };
-		5BFED7C82BD65DF10051D91B /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 5BFED7C72BD65DF10051D91B /* Realm */; };
-		5BFED7CA2BD65DF10051D91B /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 5BFED7C92BD65DF10051D91B /* RealmSwift */; };
+		5BEA73022BD77D8C00BF5ADA /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 5BEA73012BD77D8C00BF5ADA /* Realm */; };
+		5BEA73042BD77D8C00BF5ADA /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 5BEA73032BD77D8C00BF5ADA /* RealmSwift */; };
+		5BEA73062BD77F6E00BF5ADA /* ServiceStateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEA73052BD77F6E00BF5ADA /* ServiceStateViewModel.swift */; };
+		5BEA730C2BD7D17700BF5ADA /* EndingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEA730B2BD7D17700BF5ADA /* EndingView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -187,7 +187,7 @@
 		5B68A4252B8454790004E89A /* ServieStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServieStateView.swift; sourceTree = "<group>"; };
 		5B68A4332B845DDE0004E89A /* ModifierInitFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModifierInitFile.swift; sourceTree = "<group>"; };
 		5B68A4362B845E200004E89A /* View+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
-		5B72DDC72B91BA8B002EA734 /* EndingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndingViewModel.swift; sourceTree = "<group>"; };
+		5B72DDC72B91BA8B002EA734 /* EpilogueViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpilogueViewModel.swift; sourceTree = "<group>"; };
 		5B9152A72B84402C0068418F /* OnboardingTextBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTextBox.swift; sourceTree = "<group>"; };
 		5BA395432B7252C00019A545 /* GameManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameManager.swift; sourceTree = "<group>"; };
 		5BA395562B7E2EE80019A545 /* Font+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Font+.swift"; sourceTree = "<group>"; };
@@ -206,7 +206,7 @@
 		5BA395832B82495B0019A545 /* OnboardingNamingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingNamingView.swift; sourceTree = "<group>"; };
 		5BA395852B824D950019A545 /* NameSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameSettingView.swift; sourceTree = "<group>"; };
 		5BA395872B826CEA0019A545 /* OnboardingCompletionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCompletionView.swift; sourceTree = "<group>"; };
-		5BA885832B90698900041393 /* EndingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndingView.swift; sourceTree = "<group>"; };
+		5BA885832B90698900041393 /* EpilogueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpilogueView.swift; sourceTree = "<group>"; };
 		5BA931102B62602200F48AF1 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		5BA931122B62603200F48AF1 /* Plant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plant.swift; sourceTree = "<group>"; };
 		5BA931142B62604800F48AF1 /* Chapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chapter.swift; sourceTree = "<group>"; };
@@ -217,6 +217,8 @@
 		5BBABDE22BCD716800F51288 /* GardenARViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GardenARViewModel.swift; sourceTree = "<group>"; };
 		5BDA85462BCC156400C5C67C /* GardenARView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GardenARView.swift; sourceTree = "<group>"; };
 		5BE2F62F2BC03AF90049A988 /* GardenScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GardenScene.swift; sourceTree = "<group>"; };
+		5BEA73052BD77F6E00BF5ADA /* ServiceStateViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceStateViewModel.swift; sourceTree = "<group>"; };
+		5BEA730B2BD7D17700BF5ADA /* EndingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndingView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -224,8 +226,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5BFED7CA2BD65DF10051D91B /* RealmSwift in Frameworks */,
-				5BFED7C82BD65DF10051D91B /* Realm in Frameworks */,
+				5BEA73042BD77D8C00BF5ADA /* RealmSwift in Frameworks */,
+				5BEA73022BD77D8C00BF5ADA /* Realm in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -546,7 +548,8 @@
 			children = (
 				0E1AE7102B80A77A001C9A30 /* MainViewModel.swift */,
 				5BA395632B7E4A230019A545 /* OnboardingViewModel.swift */,
-				5B72DDC72B91BA8B002EA734 /* EndingViewModel.swift */,
+				5BEA73052BD77F6E00BF5ADA /* ServiceStateViewModel.swift */,
+				5B72DDC72B91BA8B002EA734 /* EpilogueViewModel.swift */,
 				0E4AB2332BCD6CE900ADB623 /* HistoryViewModel.swift */,
 				5BBABDE22BCD716800F51288 /* GardenARViewModel.swift */,
 			);
@@ -583,7 +586,7 @@
 			isa = PBXGroup;
 			children = (
 				0EF5FEA72B4FC2F500D64E5E /* View */,
-				5BA885832B90698900041393 /* EndingView.swift */,
+				5BEA730A2BD7D14600BF5ADA /* Ending */,
 				0EF5FEA82B4FC2FC00D64E5E /* ViewModel */,
 				0EF5FEA92B4FC30300D64E5E /* Model */,
 				0EF5FEAA2B4FC39300D64E5E /* Utils */,
@@ -661,6 +664,15 @@
 			path = Scenes;
 			sourceTree = "<group>";
 		};
+		5BEA730A2BD7D14600BF5ADA /* Ending */ = {
+			isa = PBXGroup;
+			children = (
+				5BA885832B90698900041393 /* EpilogueView.swift */,
+				5BEA730B2BD7D17700BF5ADA /* EndingView.swift */,
+			);
+			path = Ending;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -679,8 +691,8 @@
 			);
 			name = ForestTori;
 			packageProductDependencies = (
-				5BFED7C72BD65DF10051D91B /* Realm */,
-				5BFED7C92BD65DF10051D91B /* RealmSwift */,
+				5BEA73012BD77D8C00BF5ADA /* Realm */,
+				5BEA73032BD77D8C00BF5ADA /* RealmSwift */,
 			);
 			productName = ForestTori;
 			productReference = 0EF5FE922B4FC02100D64E5E /* ForestTori.app */;
@@ -817,12 +829,13 @@
 				5B68A4352B845DFE0004E89A /* Font+.swift in Sources */,
 				5BA395442B7252C00019A545 /* GameManager.swift in Sources */,
 				0E1AE7002B7E1880001C9A30 /* MainView.swift in Sources */,
+				5BEA730C2BD7D17700BF5ADA /* EndingView.swift in Sources */,
 				5BABC2C92B899D8B00C74E3C /* GardenView.swift in Sources */,
 				0E1AE7032B7E1892001C9A30 /* PlantView.swift in Sources */,
 				0E4AB2342BCD6CE900ADB623 /* HistoryViewModel.swift in Sources */,
 				5B68A4372B845E200004E89A /* View+.swift in Sources */,
 				5BA395842B82495B0019A545 /* OnboardingNamingView.swift in Sources */,
-				5BA885842B90698900041393 /* EndingView.swift in Sources */,
+				5BA885842B90698900041393 /* EpilogueView.swift in Sources */,
 				0E4AB2322BCD66A400ADB623 /* ImagePicker.swift in Sources */,
 				0E4AB2282BC90A4C00ADB623 /* ProgressStyle.swift in Sources */,
 				0E4AB2412BD1090B00ADB623 /* Date+.swift in Sources */,
@@ -839,7 +852,7 @@
 				5BA395862B824D950019A545 /* NameSettingView.swift in Sources */,
 				0EF5FE962B4FC02100D64E5E /* ForestToriApp.swift in Sources */,
 				0E4AB23F2BD0FD6400ADB623 /* KeyboardHandler.swift in Sources */,
-				5B72DDC82B91BA8B002EA734 /* EndingViewModel.swift in Sources */,
+				5B72DDC82B91BA8B002EA734 /* EpilogueViewModel.swift in Sources */,
 				5B9152A82B84402C0068418F /* OnboardingTextBox.swift in Sources */,
 				5BA3955E2B7E377D0019A545 /* OnboardingGreetingView.swift in Sources */,
 				0E58AB822B85BF5C00EB8C78 /* SelectPlantView.swift in Sources */,
@@ -854,6 +867,7 @@
 				0E58AB8F2B8E05AA00EB8C78 /* CompleteMissionView.swift in Sources */,
 				0E4AB2382BCD721700ADB623 /* History.swift in Sources */,
 				5BA931112B62602200F48AF1 /* User.swift in Sources */,
+				5BEA73062BD77F6E00BF5ADA /* ServiceStateViewModel.swift in Sources */,
 				5BDA85472BCC156400C5C67C /* GardenARView.swift in Sources */,
 				0E1AE7112B80A77A001C9A30 /* MainViewModel.swift in Sources */,
 				5BA395712B7F84410019A545 /* Onboarding.swift in Sources */,
@@ -1083,12 +1097,12 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		5BFED7C72BD65DF10051D91B /* Realm */ = {
+		5BEA73012BD77D8C00BF5ADA /* Realm */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 0E4AB22C2BCD3EBE00ADB623 /* XCRemoteSwiftPackageReference "realm-swift" */;
 			productName = Realm;
 		};
-		5BFED7C92BD65DF10051D91B /* RealmSwift */ = {
+		5BEA73032BD77D8C00BF5ADA /* RealmSwift */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 0E4AB22C2BCD3EBE00ADB623 /* XCRemoteSwiftPackageReference "realm-swift" */;
 			productName = RealmSwift;

--- a/ForestTori/ForestTori.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ForestTori/ForestTori.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,12 @@
 {
-  "originHash" : "182db11c87d1734fe53a6366b674339f70901a93290bd85def29b63e25e34c43",
   "pins" : [
     {
       "identity" : "realm-core",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/realm-core.git",
       "state" : {
-        "revision" : "f3417640021f329480035f432840eb0e5d0e1957",
-        "version" : "14.5.0"
+        "revision" : "4d815c6e6883bfdcb67cf755d0f0f29a4b399ea7",
+        "version" : "14.5.2"
       }
     },
     {
@@ -16,9 +15,9 @@
       "location" : "https://github.com/realm/realm-swift.git",
       "state" : {
         "branch" : "master",
-        "revision" : "2f0274f59a4771d1e778574f4315a320a5ed08a9"
+        "revision" : "3a9586b62042a4e010f3d3439b67a4779017fe07"
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/ForestTori/ForestTori/Resource/Chapters/SummerPlants.tsv
+++ b/ForestTori/ForestTori/Resource/Chapters/SummerPlants.tsv
@@ -1,5 +1,5 @@
 id	characterName	characterImage	characterDescription	mainQuest	missions	characterFileName	character3DFiles	totalDay	garden3DFile	gardenPositionX	gardenPositionZ
-1	선인장	PlantSelect_Summer1	꿈을 찾으려 먼 사막에서 온 작은 선인장 친구는 자신이 무엇을 좋아하는지 몰라 난처해하고 있어요. 함께 찾아볼까요?	"\""내가 좋아하는 것이 뭘까?\"" 기록해보기"	"1:\""내가 좋아하는 것이 뭘까?\"" 기록해보기 1|2:\""내가 좋아하는 것이 뭘까?\"" 기록해보기 2|3:\""내가 좋아하는 것이 뭘까?\"" 기록해보기 3|4:\""내가 좋아하는 것이 뭘까?\"" 기록해보기 4|5:\""내가 좋아하는 것이 뭘까?\"" 기록해보기 5|6:\""내가 좋아하는 것이 뭘까?\"" 기록해보기 6|7:\""내가 좋아하는 것이 뭘까?\"" 기록해보기 7"	SummerCharacter	Cactus1.scn|Cactus2.scn|Cactus3.scn|Cactus3.scn|Cactus3.scn|Cactus3.scn|Cactus3.scn	7	Garden_CactusAnimation.scn	1.5	-2
+1	선인장	PlantSelect_Summer1	꿈을 찾으려 먼 사막에서 온 작은 선인장 친구는 자신이 무엇을 좋아하는지 몰라 난처해하고 있어요. 함께 찾아볼까요?	내가 좋아하는 것이 뭘까? 기록해보기	1:내가 좋아하는 것이 뭘까? 기록해보기 1|2:내가 좋아하는 것이 뭘까? 기록해보기 2|3:내가 좋아하는 것이 뭘까? 기록해보기 3|4:내가 좋아하는 것이 뭘까? 기록해보기 4|5:내가 좋아하는 것이 뭘까? 기록해보기 5|6:내가 좋아하는 것이 뭘까? 기록해보기 6|7:내가 좋아하는 것이 뭘까? 기록해보기 7	SummerCharacter	Cactus1.scn|Cactus2.scn|Cactus3.scn|Cactus3.scn|Cactus3.scn|Cactus3.scn|Cactus3.scn	7	Garden_CactusAnimation.scn	1.5	-2
 2	???	PlantSelect_Summer2	???	???				0
 3	???	PlantSelect_Summer3	???	???				0
 4	???	PlantSelect_Summer4	???	???				0			

--- a/ForestTori/ForestTori/Source/Ending/EndingView.swift
+++ b/ForestTori/ForestTori/Source/Ending/EndingView.swift
@@ -1,0 +1,28 @@
+//
+//  EndingView.swift
+//  ForestTori
+//
+//  Created by Nayeon Kim on 4/23/24.
+//
+
+import SwiftUI
+
+struct EndingView: View {
+    @EnvironmentObject var gameManager: GameManager
+    
+    @AppStorage("_isEpliogueShowed") var isEpliogueShowed = false
+    
+    var body: some View {
+        if !isEpliogueShowed {
+            EpliogueView(isEpilogueShowed: $isEpliogueShowed)
+                .environmentObject(gameManager)
+        } else {
+            GardenView()
+                .environmentObject(gameManager)
+        }
+    }
+}
+
+#Preview {
+    EndingView()
+}

--- a/ForestTori/ForestTori/Source/Ending/EpilogueView.swift
+++ b/ForestTori/ForestTori/Source/Ending/EpilogueView.swift
@@ -7,9 +7,11 @@
 
 import SwiftUI
 
-struct EndingView: View {
-    @ObservedObject var endingViewModel: EndingViewModel
+struct EpliogueView: View {
+    @EnvironmentObject var gameManager: GameManager
+    @StateObject var epilgoueViewModel = EpilogueViewModel()
     
+    @Binding var isEpilogueShowed: Bool
     @State var isHidden = false
     @State var textIndex = 0
     @State var timer: Timer?
@@ -29,7 +31,7 @@ struct EndingView: View {
                             .resizable()
                             .scaledToFit()
                         
-                        OnboardingTextBox(texts: endingViewModel.endingTexts[textIndex])
+                        OnboardingTextBox(texts: epilgoueViewModel.endingTexts[textIndex])
                             .font(.titleL)
                             .foregroundColor(.brownPrimary)
                     }
@@ -37,22 +39,32 @@ struct EndingView: View {
                     VStack {
                         Spacer()
                         
-                        OnboardingDoneButton(action: endingViewModel.completeEndingProcess, label: doneButtonLabel)
-                            .foregroundColor(.yellowTertiary)
-                            .background {
-                                RoundedRectangle(cornerRadius: 50)
-                                    .fill(.brownPrimary)
-                            }
-                            .hidden(isHidden)
+                        NavigationLink(destination: GardenView()
+                            .environmentObject(gameManager).navigationBarBackButtonHidden(true)) {
+                            Text(doneButtonLabel)
+                                .font(.titleL)
+                                .padding()
+                                .frame(maxWidth: .infinity)
+                                .foregroundColor(.yellowTertiary)
+                                .background {
+                                    RoundedRectangle(cornerRadius: 50)
+                                        .fill(.brownPrimary)
+                                }
+                                .hidden(isHidden)
+                        }
                     }
                 }
                 .padding(20)
                 .toolbar {
                     OnboardingSkipButton(action: skipToLastText)
+                        .hidden(!isHidden)
                 }
             }
             .onAppear {
                 increaseTextIndex()
+            }
+            .onDisappear {
+                isEpilogueShowed = true
             }
         }
     }
@@ -60,7 +72,7 @@ struct EndingView: View {
 
 // MARK: - functions
 
-extension EndingView {
+extension EpliogueView {
     private func skipToLastText() {
         stopTimer()
         withAnimation(.easeInOut(duration: 1)) {
@@ -88,5 +100,5 @@ extension EndingView {
 }
 
 #Preview {
-    EndingView(endingViewModel: EndingViewModel())
+    EpliogueView(isEpilogueShowed: .constant(false))
 }

--- a/ForestTori/ForestTori/Source/Utils/Component/Scenes/GardenScene.swift
+++ b/ForestTori/ForestTori/Source/Utils/Component/Scenes/GardenScene.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import SceneKit
 
 struct GardenScene: UIViewRepresentable {
-    @StateObject var gameManager: GameManager
+    @EnvironmentObject var gameManager: GameManager
     
     private let gardenObject = "Gardenground.scn"
     private let lightNode = SCNNode()

--- a/ForestTori/ForestTori/Source/Utils/Manager/GameManager.swift
+++ b/ForestTori/ForestTori/Source/Utils/Manager/GameManager.swift
@@ -13,6 +13,7 @@ import SwiftUI
 /// - dataManager: 게임 데이터를 관리하는 클래스
 /// - isSelectPlant: 식물 선택 여부
 class GameManager: ObservableObject {
+    @EnvironmentObject var serviceStateViewModel: ServiceStateViewModel
     @Published var user = User()
     @Published var chapter: Chapter
     @Published var isSelectPlant = false
@@ -63,9 +64,7 @@ class GameManager: ObservableObject {
     func completeMission() {
         user.chapterProgress += 1
         
-        if user.chapterProgress == 5 {
-            // TODO: 엔딩
-        } else {
+        if user.chapterProgress < 5 {
             chapter = dataManager.chapters[user.chapterProgress - 1]
         }
         

--- a/ForestTori/ForestTori/Source/View/Garden/GardenView.swift
+++ b/ForestTori/ForestTori/Source/View/Garden/GardenView.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 struct GardenView: View {
-    @StateObject var gameManager = GameManager()
+    @Environment(\.presentationMode) var presentationMode
+    @EnvironmentObject var gameManager: GameManager
     
     @State var showSummerMessage = true
     
@@ -24,6 +25,7 @@ struct GardenView: View {
                 
                 VStack {
                     gardenHeader
+                        .hidden(gameManager.user.chapterProgress <= 4)
                     
                     Spacer()
                     
@@ -32,6 +34,7 @@ struct GardenView: View {
                             .hidden(gameManager.chapter.chapterId == 2 && showSummerMessage)
                         
                         GardenScene()
+                            .environmentObject(gameManager)
                             .scaledToFit()
                         
                         noPlantCaptionBox
@@ -47,11 +50,6 @@ struct GardenView: View {
             }
             .ignoresSafeArea()
             .navigationBarBackButtonHidden(true)
-            .onAppear{
-                print(gameManager.chapter.chapterTitle)
-                print(gameManager.chapter.chatperBackgroundImage)
-                print(gameManager.user.chapterProgress)
-            }
         }
     }
 }
@@ -61,9 +59,9 @@ struct GardenView: View {
 extension GardenView {
     @ViewBuilder private var gardenHeader: some View {
         HStack {
-            NavigationLink(
-                destination: MainView().navigationBarBackButtonHidden(true)
-            ) {
+            Button {
+                presentationMode.wrappedValue.dismiss()
+            } label: {
                 Image(.gardenButton)
                     .resizable()
                     .scaledToFit()
@@ -157,5 +155,5 @@ extension GardenView {
 }
 
 #Preview {
-    GardenView(gameManager: GameManager())
+    GardenView()
 }

--- a/ForestTori/ForestTori/Source/View/Main/CompleteMissionView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/CompleteMissionView.swift
@@ -48,6 +48,7 @@ struct CompleteMissionView: View {
                 
                 HStack(spacing: 16) {
                     NavigationLink(destination: GardenView()
+                        .environmentObject(gameManager)
                         .navigationBarBackButtonHidden(true)
                     ) {
                         Text("정원으로")

--- a/ForestTori/ForestTori/Source/View/Main/MainView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/MainView.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 struct MainView: View {
-    @StateObject var gameManager = GameManager()
+    @EnvironmentObject var gameManager: GameManager
+    @EnvironmentObject var serviceStateViewModel: ServiceStateViewModel
     @StateObject var viewModel = MainViewModel()
     @StateObject private var keyboardHandler = KeyboardHandler()
     
@@ -20,7 +21,7 @@ struct MainView: View {
             ZStack {
                 Image(gameManager.chapter.chatperBackgroundImage)
                     .resizable()
-                    .scaledToFit()
+                    .ignoresSafeArea()
                 
                 VStack {
                     mainHeader
@@ -34,28 +35,11 @@ struct MainView: View {
                     customTabBar
                 }
                 
-                if isShowSelectPlantView {
-                    Color.black.opacity(0.4)
-                    
-                    Text("식물 친구를 선택해주세요")
-                        .font(.titleM)
-                        .foregroundColor(.white)
-                        .padding(.top, 160)
-                        .frame(maxHeight: .infinity, alignment: .top)
-                    
-                    SelectPlantView(isShowSelectPlantView: $isShowSelectPlantView)
-                        .environmentObject(gameManager)
-                }
+                showSelectPlantView
                 
-                if viewModel.isCompleteMission {
-                    Color.black.opacity(0.4)
-                    
-                    CompleteMissionView()
-                        .environmentObject(gameManager)
-                        .onAppear {
-                            gameManager.completeMission()
-                        }
-                }
+                showCompleteMission
+                
+                showHistoryView
             }
             .ignoresSafeArea()
             .onChange(of: gameManager.isSelectPlant) {
@@ -64,6 +48,10 @@ struct MainView: View {
                 } else {
                     viewModel.setEmptyPot()
                 }
+            }
+            .onChange(of: viewModel.showEnding) {
+                gameManager.completeMission()
+                serviceStateViewModel.state = .ending
             }
         }
     }
@@ -75,6 +63,7 @@ extension MainView {
     private var mainHeader: some View {
         HStack {
             NavigationLink(destination: GardenView()
+                .environmentObject(gameManager)
                 .navigationBarBackButtonHidden(true)
             ) {
                 Image("MainButton")

--- a/ForestTori/ForestTori/Source/View/Main/PlantCardView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/PlantCardView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct PlantCardView: View {
     @EnvironmentObject var gameManager: GameManager
+    
     @Binding var isShowSelectPlantView: Bool
     
     var plant: Plant

--- a/ForestTori/ForestTori/Source/View/Main/SelectPlantView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/SelectPlantView.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct SelectPlantView: View {
     @EnvironmentObject var gameManager: GameManager
-    @State private var currentIndex = 0
     
+    @State private var currentIndex = 0
     @Binding var isShowSelectPlantView: Bool
     
     var body: some View {

--- a/ForestTori/ForestTori/Source/View/Onboarding/NameSettingView.swift
+++ b/ForestTori/ForestTori/Source/View/Onboarding/NameSettingView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct NameSettingView: View {
-    @ObservedObject var onboardingViewModel: OnboardingViewModel
+    @EnvironmentObject var onboardingViewModel: OnboardingViewModel
     
     @State var name = ""
     @State var isNameAvailable = false
@@ -129,5 +129,5 @@ extension NameSettingView {
 }
 
 #Preview {
-    NameSettingView(onboardingViewModel: OnboardingViewModel(), isCompleted: .constant(false), isPresented: .constant(true), textIndex: .constant(0))
+    NameSettingView(isCompleted: .constant(false), isPresented: .constant(true), textIndex: .constant(0))
 }

--- a/ForestTori/ForestTori/Source/View/Onboarding/OnboardingCompletionView.swift
+++ b/ForestTori/ForestTori/Source/View/Onboarding/OnboardingCompletionView.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 struct OnboardingCompletionView: View {
-    @ObservedObject var onboardingViewModel: OnboardingViewModel
+    @EnvironmentObject var serviceStateViewModel: ServiceStateViewModel
+    @EnvironmentObject var onboardingViewModel: OnboardingViewModel
     
     private let doneButtonLabel = "시작하기"
     
@@ -27,7 +28,8 @@ struct OnboardingCompletionView: View {
             VStack {
                 Spacer()
                 
-                OnboardingDoneButton(action: onboardingViewModel.completeOnboardingProcess, label: doneButtonLabel)
+                OnboardingDoneButton(action: { serviceStateViewModel.state = .main
+                }, label: doneButtonLabel)
                     .font(.titleL)
                     .foregroundColor(.yellowTertiary)
                     .background {
@@ -41,5 +43,5 @@ struct OnboardingCompletionView: View {
 }
 
 #Preview {
-    OnboardingCompletionView(onboardingViewModel: OnboardingViewModel())
+    OnboardingView()
 }

--- a/ForestTori/ForestTori/Source/View/Onboarding/OnboardingGreetingView.swift
+++ b/ForestTori/ForestTori/Source/View/Onboarding/OnboardingGreetingView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct OnboardingGreetingView: View {
-    @ObservedObject var onboardingViewModel: OnboardingViewModel
+    @EnvironmentObject var onboardingViewModel: OnboardingViewModel
     
     @State var isHidden = false
     @State var textIndex = 0
@@ -64,5 +64,5 @@ extension OnboardingGreetingView {
 }
 
 #Preview {
-    OnboardingGreetingView(onboardingViewModel: OnboardingViewModel())
+    OnboardingView()
 }

--- a/ForestTori/ForestTori/Source/View/Onboarding/OnboardingIntroductionView.swift
+++ b/ForestTori/ForestTori/Source/View/Onboarding/OnboardingIntroductionView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct OnboardingIntroductionView: View {
-    @ObservedObject var onboardingViewModel: OnboardingViewModel
+    @EnvironmentObject var onboardingViewModel: OnboardingViewModel
     
     @State var isHidden = false
     
@@ -99,5 +99,5 @@ extension OnboardingIntroductionView {
 }
 
 #Preview {
-    OnboardingIntroductionView(onboardingViewModel: OnboardingViewModel())
+    OnboardingView()
 }

--- a/ForestTori/ForestTori/Source/View/Onboarding/OnboardingNamingView.swift
+++ b/ForestTori/ForestTori/Source/View/Onboarding/OnboardingNamingView.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 struct OnboardingNamingView: View {
-    @ObservedObject var onboardingViewModel: OnboardingViewModel
+    @EnvironmentObject var gameManager: GameManager
+    @EnvironmentObject var onboardingViewModel: OnboardingViewModel
     
     @State var isNamingCompleted = false
     @State var isSettingViewPresented = false
@@ -52,7 +53,7 @@ struct OnboardingNamingView: View {
 extension OnboardingNamingView {
     @ViewBuilder private var overlayView: some View {
         if isSettingViewPresented {
-            NameSettingView(onboardingViewModel: onboardingViewModel, isCompleted: $isNamingCompleted, isPresented: $isSettingViewPresented, textIndex: $textIndex)
+            NameSettingView(isCompleted: $isNamingCompleted, isPresented: $isSettingViewPresented, textIndex: $textIndex)
         } else {
             EmptyView()
         }
@@ -102,5 +103,5 @@ extension OnboardingNamingView {
 }
 
 #Preview {
-    OnboardingNamingView(onboardingViewModel: OnboardingViewModel())
+    OnboardingView()
 }

--- a/ForestTori/ForestTori/Source/View/Onboarding/OnboardingView.swift
+++ b/ForestTori/ForestTori/Source/View/Onboarding/OnboardingView.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 struct OnboardingView: View {
-    @ObservedObject var onboardingViewModel: OnboardingViewModel
+    @EnvironmentObject var serviceStateViewModel: ServiceStateViewModel
+    @StateObject var onboardingViewModel = OnboardingViewModel()
     
     var body: some View {
         NavigationView {
@@ -29,13 +30,18 @@ extension OnboardingView {
     @ViewBuilder private var onboardingScreen: some View {
         switch onboardingViewModel.type {
         case .greeting:
-            OnboardingGreetingView(onboardingViewModel: onboardingViewModel)
+            OnboardingGreetingView()
+                .environmentObject(onboardingViewModel)
         case .introduction:
-            OnboardingIntroductionView(onboardingViewModel: onboardingViewModel)
+            OnboardingIntroductionView()
+                .environmentObject(onboardingViewModel)
         case .naming:
-            OnboardingNamingView(onboardingViewModel: onboardingViewModel)
+            OnboardingNamingView()
+                .environmentObject(onboardingViewModel)
         case .completion:
-            OnboardingCompletionView(onboardingViewModel: onboardingViewModel)
+            OnboardingCompletionView()
+                .environmentObject(serviceStateViewModel)
+                .environmentObject(onboardingViewModel)
         }
     }
 }

--- a/ForestTori/ForestTori/Source/View/ServieStateView.swift
+++ b/ForestTori/ForestTori/Source/View/ServieStateView.swift
@@ -8,11 +8,12 @@
 import SwiftUI
 
 struct ServiceStateView: View {
-    @StateObject var onboardingViewModel = OnboardingViewModel()
+    @StateObject var gameManager = GameManager()
+    @StateObject var serviceStateViewModel = ServiceStateViewModel()
     
     var body: some View {
-//        stateBasedView
-        MainView()
+        stateBasedView
+//        MainView()
     }
 }
 
@@ -20,11 +21,17 @@ struct ServiceStateView: View {
 
 extension ServiceStateView {
     @ViewBuilder private var stateBasedView: some View {
-        // TODO: enum으로 관리
-        if onboardingViewModel.isFirstLaunching {
-            OnboardingView(onboardingViewModel: onboardingViewModel)
-        } else {
+        switch serviceStateViewModel.state {
+        case .onboarding:
+            OnboardingView()
+                .environmentObject(serviceStateViewModel)
+        case .main:
             MainView()
+                .environmentObject(gameManager)
+                .environmentObject(serviceStateViewModel)
+        case .ending:
+            EndingView()
+                .environmentObject(gameManager)
         }
     }
 }

--- a/ForestTori/ForestTori/Source/ViewModel/EpilogueViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/EpilogueViewModel.swift
@@ -11,10 +11,9 @@ import SwiftUI
 ///  EndingView에서 사용하는 데이터를 관리하는 클래스
 ///
 ///  - endingTexts: 엔딩에서 사용하는 텍스트 데이터 집합
-class EndingViewModel: ObservableObject {
+class EpilogueViewModel: ObservableObject {
     @Published var endingTexts: [[OnboardingText]] = []
     
-    // TODO: 사용자 관련 변수 분리해서 관리하기
     let onboardingViewModel = OnboardingViewModel()
     let userName: String
     
@@ -24,7 +23,7 @@ class EndingViewModel: ObservableObject {
     }
 }
 
-extension EndingViewModel {
+extension EpilogueViewModel {
     func completeEndingProcess() {
         // TODO: 엔딩 완료 함수 수정
         print("complete ending process")
@@ -33,7 +32,7 @@ extension EndingViewModel {
 
 // MARK: Data Initialization
 
-extension EndingViewModel {
+extension EpilogueViewModel {
     private func setEndingTexts() {
         let firstText = [
             OnboardingText(text: "\(Text(userName).foregroundColor(.greenPrimary))"),

--- a/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
@@ -37,6 +37,8 @@ class MainViewModel: ObservableObject {
         }
     }
     
+    @Published var showEnding = false
+    
     @Published var progressValue: Float = 0.0
     @Published var plantName = ""
     
@@ -104,7 +106,7 @@ class MainViewModel: ObservableObject {
     func completMission() {
         currentDialogueIndex += 1
         currentLineIndex = 0
-        progressValue = (Float(missionDay+1)/Float(plant?.totalDay ?? 0)) * 100
+        progressValue = (Float(missionDay + 1)/Float(plant?.totalDay ?? 0)) * 100
         
         isShowDialogueBox = true
         isDisableDoneButton = true
@@ -152,14 +154,18 @@ class MainViewModel: ObservableObject {
 
         if let plant = plant {
             if missionDay == plant.totalDay {
-                isCompleteMission = true
-                isShowDialogueBox = false
-                isShowMissionBox = false
+                if plant.characterImage.contains("Winter") {
+                    showEnding = true
+                } else {
+                    isCompleteMission = true
+                    isShowDialogueBox = false
+                    isShowMissionBox = false
+                }
             } else {
                 plant3DFileName = plant.character3DFiles[missionDay]
                 missionText = plant.missions[missionDay].content
                 
-                if dialogues[currentDialogueIndex+1].type == "Opening" {
+                if dialogues[currentDialogueIndex + 1].type == "Opening" {
                     currentDialogueIndex += 1
                     currentLineIndex = 0
                     

--- a/ForestTori/ForestTori/Source/ViewModel/OnboardingViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/OnboardingViewModel.swift
@@ -16,7 +16,7 @@ import SwiftUI
 /// - onboardingNamingTexts: 사용자 이름 설정 단계에서 사용하는 텍스트 집합
 /// - onboardingCompletionText: 온보딩 완료 단계에서 사용하는 텍스트 집합
 class OnboardingViewModel: ObservableObject {
-    @AppStorage("_isFirstLaunching") var isFirstLaunching = true
+//    @AppStorage("_isFirstLaunching") var isFirstLaunching = true
     // TODO: 사용자 관련 변수 분리해서 관리하기
     @AppStorage("userName") var userName = ""
     
@@ -66,9 +66,9 @@ extension OnboardingViewModel {
         setOnboardingCompletionText()
     }
     
-    func completeOnboardingProcess() {
-        isFirstLaunching = false
-    }
+//    func completeOnboardingProcess() {
+//        isFirstLaunching = false
+//    }
 }
 
 // MARK: - Data Initialization

--- a/ForestTori/ForestTori/Source/ViewModel/ServiceStateViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/ServiceStateViewModel.swift
@@ -1,0 +1,23 @@
+//
+//  ServiceStateViewModel.swift
+//  ForestTori
+//
+//  Created by Nayeon Kim on 4/23/24.
+//
+
+import SwiftUI
+
+class ServiceStateViewModel: ObservableObject {
+    // TODO: 기능 통합 완료 후, .onboarding으로 수정
+    @AppStorage("serviceState") var state: ServiceState = .main
+    
+    /// 서비스 상태 유형
+    ///
+    /// @AppStorage에 저장하기 위해 String으로 선언
+    /// - onboarding: 온보딩 단계
+    /// - main: 메인 스토리 진행 단계
+    /// - ending: 메인 스토리 완료 이후 단계
+    enum ServiceState: String {
+        case onboarding, main, ending
+    }
+}


### PR DESCRIPTION
## 📌 Summary
<!-- 이슈 번호
     이슈가 없다면 이 작업을 하게 된 이유 
     작업 내용 요약 -->
- resolve: #37 

<br>

## ✨ Description
<!-- 작업 내용 -->
- 엔딩 단계를 포함하여 온보딩, 메인, 엔딩 전 단계를 통합하였습니다.
   - ServiceStateViewModel를 활용하여 각 단계가 끝날 때마다 다음 단계로 넘어갈 수 있도록 하였습니다.
   - 단, 다른 뷰에서도 활용되는 만큼 추후에 PageManager나 ProgressManager로 이름을 변경할 예정입니다.
```swift
class ServiceStateViewModel: ObservableObject {
    // TODO: 기능 통합 완료 후, .onboarding으로 수정
    @AppStorage("serviceState") var state: ServiceState = .main
    
    /// 서비스 상태 유형
    ///
    /// @AppStorage에 저장하기 위해 String으로 선언
    /// - onboarding: 온보딩 단계
    /// - main: 메인 스토리 진행 단계
    /// - ending: 메인 스토리 완료 이후 단계
    enum ServiceState: String {
        case onboarding, main, ending
    }
}
```
- 또한, 각 단계를 연결하면서 엔딩에서도 정원을 그리기 위해 GameManager가 필요한 것을 확인하였습니다. 
   - 따라서, 원래 Main에서 GameManager를 선언하고 하위 뷰에 전달하였던 구조에서
   - ServiceStateView에서 GameManager를 선언하고 하위 뷰에 전달하는 구조로 수정하였습니다. 
- Main) 목화 나무 플레이 이후 엔딩으로 넘어가는 로직을 추가하기 위해 임의로 다음과 같이 처리하였습니다.
   - MainViewModel에 `showEnding` 변수 추가하여 식물이 겨울 식물이면 `showEnding`을 참으로 변경
   ```swift
   if missionDay == plant.totalDay {
                if plant.characterImage.contains("Winter") {
                    showEnding = true
                } else {
                    isCompleteMission = true
                    isShowDialogueBox = false
                    isShowMissionBox = false
                }
            }
    ```
   - MainView에서 showEnding 값 변화를 감지하면 ending 단계로 전환
   ```swift
   .onChange(of: viewModel.showEnding) {
                gameManager.completeMission()
                serviceStateViewModel.state = .ending
            }
   ```
- 이외에 여름 식물 파일 수정, 자잘한 로직 수정 등이 있습니다.

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|메인 ➡️ 에필로그|<img src = "https://github.com/DevTillDie/ForestTori/assets/97589973/cd3c1193-530f-4bce-8acd-94b396c07491" width ="250">|
|에필로그 이후|<img src = "https://github.com/DevTillDie/ForestTori/assets/97589973/c7ebea6c-d8de-4eca-a266-e396f623bce6" width ="250"> <br>정원 헤더 hidden 처리 🆗|

<br>

## 🗒️ Review Point
```
다음을 확인해 주세요.
1. ServiceStateView에서 StateObject로 GameManager 선언 후, 하위 뷰로 전달
2. 메인 - 엔딩 전환 코드

다음을 추가로 진행할 예정입니다.
1. 온보딩 - 메인 - 엔딩 전환 애니메이션 추가
2. 한 번 더 리팩토링 (통합 작업이라 자잘한 코드 수정이 많았고 임의로 처리한 코드들이 있어서 한 번 더 다듬을 필요가 있을 것 같아요!)
```
