### PR TITLE
feat: add total progress bar for garden view

### DIFF
--- a/ForestTori/ForestTori/Resource/Assets.xcassets/Colors/IvoryTransparency50.colorset/Contents.json
+++ b/ForestTori/ForestTori/Resource/Assets.xcassets/Colors/IvoryTransparency50.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.500",
+          "blue" : "0xF0",
+          "green" : "0xFB",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.500",
+          "blue" : "0xF0",
+          "green" : "0xFB",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ForestTori/ForestTori/Source/Ending/EndingView.swift
+++ b/ForestTori/ForestTori/Source/Ending/EndingView.swift
@@ -25,4 +25,5 @@ struct EndingView: View {
 
 #Preview {
     EndingView()
+        .environmentObject(GameManager())
 }

--- a/ForestTori/ForestTori/Source/Ending/EpilogueView.swift
+++ b/ForestTori/ForestTori/Source/Ending/EpilogueView.swift
@@ -101,4 +101,5 @@ extension EpliogueView {
 
 #Preview {
     EpliogueView(isEpilogueShowed: .constant(false))
+        .environmentObject(GameManager())
 }

--- a/ForestTori/ForestTori/Source/Utils/Component/ProgressStyle.swift
+++ b/ForestTori/ForestTori/Source/Utils/Component/ProgressStyle.swift
@@ -35,7 +35,7 @@ struct ProgressStyle: ProgressViewStyle {
             VStack {
                 Text(text)
                     .font(.titleS)
-                Text("\(Int(progress*100))%")
+                Text("\(Int(progress * 100))%")
                     .font(.titleL)
             }
             .foregroundStyle(.white)

--- a/ForestTori/ForestTori/Source/Utils/Manager/GameManager.swift
+++ b/ForestTori/ForestTori/Source/Utils/Manager/GameManager.swift
@@ -38,11 +38,6 @@ class GameManager: ObservableObject {
     
     /// 새로운 스토리 시작
     func startNewGame() {
-        if let plant = user.selectedPlant {
-            user.completedPlants.append(plant)
-        }
-        
-        user.selectedPlant = nil
         isSelectPlant = false
         
         saveUserDataToUserDefaults()
@@ -62,6 +57,12 @@ class GameManager: ObservableObject {
     ///
     /// 미션 완료 후 호출되어 사용자의 레벌업 및 챕터 진행 상태를 확인합니다
     func completeMission() {
+        if let plant = user.selectedPlant {
+            user.completedPlants.append(plant)
+        }
+        
+        user.selectedPlant = nil
+    
         user.chapterProgress += 1
         
         if user.chapterProgress < 5 {

--- a/ForestTori/ForestTori/Source/View/Garden/GardenARView.swift
+++ b/ForestTori/ForestTori/Source/View/Garden/GardenARView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct GardenARView: View {
     @Environment(\.presentationMode) var presentationMode
+    @EnvironmentObject var gameManager: GameManager
     @StateObject var gardenARViewModel = GardenARViewModel()
     
     private var backButtonLabel = "돌아가기"
@@ -47,6 +48,7 @@ extension GardenARView {
                     showHistoryView: .constant(false)
                 )
                     .scaledToFit()
+                    .environmentObject(gameManager)
                 
                 Spacer()
                 Spacer()
@@ -94,4 +96,5 @@ extension GardenARView {
 
 #Preview {
     GardenARView()
+        .environmentObject(GameManager())
 }

--- a/ForestTori/ForestTori/Source/View/Garden/GardenView.swift
+++ b/ForestTori/ForestTori/Source/View/Garden/GardenView.swift
@@ -214,7 +214,9 @@ extension GardenView {
 
 extension GardenView {
     @ViewBuilder private var ARButton: some View {
-        NavigationLink(destination: GardenARView()) {
+        NavigationLink(destination: GardenARView()
+            .environmentObject(gameManager)
+        ) {
             Image(.arButton)
                 .resizable()
                 .scaledToFit()
@@ -226,4 +228,5 @@ extension GardenView {
 
 #Preview {
     GardenView()
+        .environmentObject(GameManager())
 }

--- a/ForestTori/ForestTori/Source/View/Garden/GardenView.swift
+++ b/ForestTori/ForestTori/Source/View/Garden/GardenView.swift
@@ -19,6 +19,7 @@ struct GardenView: View {
     
     private let noPlantCaption = "아직 다 키운 식물이 없어요."
     private let summerMessage = "여름 하늘은 봄보다 더 높아져서 더 멀리까지 바라볼 수 있는 거 알아?"
+    var totalProgressValue: Float?
     
     var body: some View {
         NavigationView {
@@ -81,18 +82,15 @@ extension GardenView {
             
             Spacer()
             
-            // TODO: TotalProgressBar 수정
-            ZStack {
-                Image(.gardenProgressSpring3)
-                VStack {
-                    Text(gameManager.chapter.chapterTitle)
-                        .font(.titleS)
-                    Text("21%")
-                        .font(.titleL)
-                }
-                .foregroundColor(.white)
-                .shadow(color: .gray30, radius: 4.0)
-            }
+            ProgressView(value: totalProgressValue ?? 100, total: 100)
+                .frame(width: 241, height: 50)
+                .progressViewStyle(
+                    ProgressStyle(
+                        width: 241,
+                        color: .ivoryTransparency50,
+                        text: gameManager.chapter.chapterTitle
+                    )
+                )
         }
         .padding(.horizontal, 20)
         .padding(.top, 69)
@@ -227,6 +225,6 @@ extension GardenView {
 }
 
 #Preview {
-    GardenView()
+    GardenView(totalProgressValue: MainViewModel().totalProgressValue)
         .environmentObject(GameManager())
 }

--- a/ForestTori/ForestTori/Source/View/Main/CompleteMissionView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/CompleteMissionView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct CompleteMissionView: View {
     @EnvironmentObject var gameManager: GameManager
+    @EnvironmentObject var mainViewModel: MainViewModel
     
     var body: some View {
         ZStack {
@@ -50,6 +51,12 @@ struct CompleteMissionView: View {
                     NavigationLink(destination: GardenView()
                         .environmentObject(gameManager)
                         .navigationBarBackButtonHidden(true)
+                        .onAppear {
+                            mainViewModel.isShowCompleteMissionView = false
+                        }
+                        .onDisappear {
+                            gameManager.startNewGame()
+                        }
                     ) {
                         Text("정원으로")
                             .font(.titleS)
@@ -89,4 +96,6 @@ struct CompleteMissionView: View {
 
 #Preview {
     CompleteMissionView()
+        .environmentObject(GameManager())
+        .environmentObject(ServiceStateViewModel())
 }

--- a/ForestTori/ForestTori/Source/View/Main/CompleteMissionView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/CompleteMissionView.swift
@@ -48,7 +48,7 @@ struct CompleteMissionView: View {
                 .padding(.horizontal, 23)
                 
                 HStack(spacing: 16) {
-                    NavigationLink(destination: GardenView()
+                    NavigationLink(destination: GardenView(totalProgressValue: mainViewModel.totalProgressValue)
                         .environmentObject(gameManager)
                         .navigationBarBackButtonHidden(true)
                         .onAppear {

--- a/ForestTori/ForestTori/Source/View/Main/MainView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/MainView.swift
@@ -43,7 +43,7 @@ struct MainView: View {
             }
             .ignoresSafeArea()
             .onChange(of: gameManager.isSelectPlant) {
-                if  gameManager.isSelectPlant {
+                if gameManager.isSelectPlant {
                     viewModel.setNewPlant(plant: gameManager.user.selectedPlant)
                 } else {
                     viewModel.setEmptyPot()
@@ -142,11 +142,16 @@ extension MainView {
                 
                 CompleteMissionView()
                     .environmentObject(gameManager)
+                    .environmentObject(viewModel)
                     .onAppear {
-                        gameManager.completeMission()
+                        if gameManager.user.selectedPlant != nil {
+                            viewModel.isShowCompleteMissionView = true
+                            gameManager.completeMission()
+                        }
                     }
             }
         }
+        .hidden(viewModel.isShowCompleteMissionView)
     }
     
     private var showHistoryView: some View {
@@ -163,7 +168,7 @@ extension MainView {
                     .transition(.opacity)
                 
                 WriteHistoryView(
-                    isComplete: $viewModel.isComplteTodayMission,
+                    isComplete: $viewModel.isCompleteTodayMission,
                     isShowHistoryView: $viewModel.isShowHistoryView,
                     isTapDoneButton: $viewModel.isTapDoneButton,
                     plantName: viewModel.plantName
@@ -185,4 +190,6 @@ extension MainView {
 
 #Preview {
     MainView()
+        .environmentObject(GameManager())
+        .environmentObject(ServiceStateViewModel())
 }

--- a/ForestTori/ForestTori/Source/View/Main/MainView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/MainView.swift
@@ -62,7 +62,7 @@ struct MainView: View {
 extension MainView {
     private var mainHeader: some View {
         HStack {
-            NavigationLink(destination: GardenView()
+            NavigationLink(destination: GardenView(totalProgressValue: viewModel.totalProgressValue)
                 .environmentObject(gameManager)
                 .navigationBarBackButtonHidden(true)
             ) {

--- a/ForestTori/ForestTori/Source/View/Main/PlantView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/PlantView.swift
@@ -112,4 +112,6 @@ extension PlantView {
 
 #Preview {
     MainView()
+        .environmentObject(GameManager())
+        .environmentObject(ServiceStateViewModel())
 }

--- a/ForestTori/ForestTori/Source/View/Main/SelectPlantView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/SelectPlantView.swift
@@ -95,4 +95,6 @@ struct PlantCarousel<Content: View, T: Identifiable>: View {
 
 #Preview {
     MainView()
+        .environmentObject(GameManager())
+        .environmentObject(ServiceStateViewModel())
 }

--- a/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
@@ -42,6 +42,7 @@ class MainViewModel: ObservableObject {
     
     @Published var progressValue: Float = 0.0
     @Published var plantName = ""
+    @Published var totalProgressValue: Float = 0.0
     
     private var plant: Plant?
     private var missionDay = 0
@@ -108,6 +109,7 @@ class MainViewModel: ObservableObject {
         currentDialogueIndex += 1
         currentLineIndex = 0
         progressValue = (Float(missionDay + 1)/Float(plant?.totalDay ?? 0)) * 100
+        totalProgressValue += (1 / Float(plant?.totalDay ?? 1)) * 25
         
         isShowDialogueBox = true
         isDisableDoneButton = true

--- a/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
@@ -19,20 +19,21 @@ class MainViewModel: ObservableObject {
     @Published var dialogueText = ""
     @Published var missionText = ""
     
-    @Published var isShowDialogueBox = false
     @Published var isShowAddButton = true
+    @Published var isShowDialogueBox = false
+    @Published var isShowHistoryView = false
     @Published var isShowMissionBox = false
+    @Published var isShowCompleteMissionView = false
     @Published var isTapDoneButton = false
     @Published var isDisableDoneButton = false
     @Published var isCompleteMission = false
-    @Published var isShowHistoryView = false
     
-    @Published var isComplteTodayMission = false {
+    @Published var isCompleteTodayMission = false {
         didSet {
-            if isComplteTodayMission == true {
+            if isCompleteTodayMission == true {
                 isShowHistoryView = false
                 completMission()
-                isComplteTodayMission = false
+                isCompleteTodayMission = false
             }
         }
     }
@@ -76,8 +77,8 @@ class MainViewModel: ObservableObject {
         dialogueText = ""
         missionText = ""
         
-        isShowDialogueBox = false
         isShowAddButton = true
+        isShowDialogueBox = false
         isShowMissionBox = false
         isTapDoneButton = false
         isDisableDoneButton = false


### PR DESCRIPTION
## 📌 Summary
- resolve: #55 

<br>

## ✨ Description
전체 스토리 진행률을 확인할 수 있는 프로그레스바를 구현하였습니다.
- 기존에 메인 뷰에서 사용하는 프로그레스바 코드를 참고하여 다음과 같이 코드를 작성하였습니다.
```swift
ProgressView(value: totalProgressValue ?? 100, total: 100)
                .frame(width: 241, height: 50)
                .progressViewStyle(
                    ProgressStyle(
                        width: 241,
                        color: .ivoryTransparency50,
                        text: gameManager.chapter.chapterTitle
                    )
                )
```
- 챕터 내 미션 진행을 포함한 전체 진행률을 나타내기 때문에, 챕터 내 미션 관리를 담당하는 `MainViewModel`에 `totalProgressValue`를 추가하여 진행률을 계산하였습니다.
```swift
@Published var totalProgressValue: Float = 0.0

func completMission() {
        ...
        totalProgressValue += (1 / Float(plant?.totalDay ?? 1)) * 25
        ...
    }
```
- `MainViewModel`에서 `totalProgressValue`변수만을 필요로 한다는 점, 그리고 메인에서 작업한 이후에 정원으로 이동해야만 전체 진행률을 확인할 수 있다는 점에서 `@EnvironmentObject`를 활용하지 않고 다음과 같이 변수를 선언하고 전달하였습니다.
```swift
// GardenView.swift
var totalProgressValue: Float?

// MainView.swift
NavigationLink(destination: GardenView(totalProgressValue: viewModel.totalProgressValue)
                .environmentObject(gameManager)
                .navigationBarBackButtonHidden(true)
            ) 
```


<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|프로그레스바 (정원)|<img src = "https://github.com/DevTillDie/ForestTori/assets/97589973/3fd96345-08c9-4d49-8524-c497503874a9" width ="250"> <img src = "https://github.com/DevTillDie/ForestTori/assets/97589973/4cd087aa-5fea-45d3-8243-7f1e062d39bd" width ="250">||

<br>

## 🗒️ Review Point
```
진행률 계산법과 변수 전달 방식에 대해서 한 번 검토해 주세요! 혹시나, 다른 의견이 있으시다면 코멘트 남겨주세요 :-)
```
