### PR TITLE
design: edit font style

### DIFF
--- a/ForestTori/ForestTori.xcodeproj/project.pbxproj
+++ b/ForestTori/ForestTori.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		0E1AE71F2B80B9B2001C9A30 /* AutumnCharacter.tsv in Resources */ = {isa = PBXBuildFile; fileRef = 0E1AE71B2B80B9B2001C9A30 /* AutumnCharacter.tsv */; };
 		0E214B5F2BDFC85500558004 /* BottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E214B5E2BDFC85500558004 /* BottomSheet.swift */; };
 		0E214B612BDFD52900558004 /* HistoryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E214B602BDFD52900558004 /* HistoryDetailView.swift */; };
+		0E214B652BE34B5A00558004 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E214B642BE34B5A00558004 /* String+.swift */; };
 		0E4AB2282BC90A4C00ADB623 /* ProgressStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4AB2272BC90A4C00ADB623 /* ProgressStyle.swift */; };
 		0E4AB22B2BCD3E7E00ADB623 /* WriteHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4AB22A2BCD3E7E00ADB623 /* WriteHistoryView.swift */; };
 		0E4AB2322BCD66A400ADB623 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4AB2312BCD66A400ADB623 /* ImagePicker.swift */; };
@@ -130,6 +131,7 @@
 		0E1AE71B2B80B9B2001C9A30 /* AutumnCharacter.tsv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = AutumnCharacter.tsv; sourceTree = "<group>"; };
 		0E214B5E2BDFC85500558004 /* BottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheet.swift; sourceTree = "<group>"; };
 		0E214B602BDFD52900558004 /* HistoryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryDetailView.swift; sourceTree = "<group>"; };
+		0E214B642BE34B5A00558004 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		0E4AB2272BC90A4C00ADB623 /* ProgressStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressStyle.swift; sourceTree = "<group>"; };
 		0E4AB22A2BCD3E7E00ADB623 /* WriteHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteHistoryView.swift; sourceTree = "<group>"; };
 		0E4AB2312BCD66A400ADB623 /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
@@ -380,6 +382,7 @@
 				0E1AE6FD2B7E185B001C9A30 /* Font+.swift */,
 				5B68A4362B845E200004E89A /* View+.swift */,
 				0E4AB2402BD1090B00ADB623 /* Date+.swift */,
+				0E214B642BE34B5A00558004 /* String+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -859,6 +862,7 @@
 				0E58AB842B8CAD1C00EB8C78 /* PlantCardView.swift in Sources */,
 				5BA931152B62604800F48AF1 /* Chapter.swift in Sources */,
 				5B68A4342B845DDE0004E89A /* ModifierInitFile.swift in Sources */,
+				0E214B652BE34B5A00558004 /* String+.swift in Sources */,
 				5BE2F6302BC03AF90049A988 /* GardenScene.swift in Sources */,
 				5BA931132B62603200F48AF1 /* Plant.swift in Sources */,
 				0E1AE7052B7E18AF001C9A30 /* PlantPotView.swift in Sources */,

--- a/ForestTori/ForestTori/Source/Utils/Extension/String+.swift
+++ b/ForestTori/ForestTori/Source/Utils/Extension/String+.swift
@@ -1,0 +1,14 @@
+//
+//  String+.swift
+//  ForestTori
+//
+//  Created by hyebin on 5/2/24.
+//
+
+import Foundation
+
+extension String {
+    func splitChatacter() -> String {
+        return self.split(separator: "").joined(separator: "\u{200B}")
+    }
+}

--- a/ForestTori/ForestTori/Source/View/Garden/HistoryDetailView.swift
+++ b/ForestTori/ForestTori/Source/View/Garden/HistoryDetailView.swift
@@ -63,7 +63,9 @@ extension HistoryDetailView {
             .fill(Color.gray10)
             .stroke(.brownSecondary, lineWidth: 2)
             .overlay(alignment: .topLeading) {
-                Text(record)
+                Text(record.splitChatacter())
+                    .font(.bodyM)
+                    .foregroundStyle(.gray50)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding()
             }

--- a/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
@@ -121,6 +121,8 @@ extension WriteHistoryView {
                     .submitLabel(.done)
                     .disableAutocorrection(true)
                     .tint(.greenSecondary)
+                    .font(.bodyM)
+                    .foregroundStyle(.gray50)
                     .padding()
             }
             .padding(.horizontal)

--- a/ForestTori/ForestTori/Source/View/Main/PlantCardView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/PlantCardView.swift
@@ -37,7 +37,7 @@ struct PlantCardView: View {
                     .cornerRadius(8)
                     .padding(.bottom, 16)
                 
-                Text(plant.characterDescription)
+                Text(plant.characterDescription.splitChatacter())
                     .font(.bodyS)
                     .foregroundStyle(.gray50)
                     .lineSpacing(1)

--- a/ForestTori/ForestTori/Source/View/Main/PlantView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/PlantView.swift
@@ -40,16 +40,18 @@ struct PlantView: View {
 
 extension PlantView {
     private var dialogueBox: some View {
-        Image("DialogFrame")
+        let fontSize: CGFloat = 17.5
+        
+        return Image("DialogFrame")
             .resizable()
             .scaledToFit()
             .overlay(alignment: .top) {
                 ZStack(alignment: .topLeading) {
-                    Text(viewModel.dialogueText)
-                        .font(.pretendard(size: 17.5, .regular))
-                        .foregroundStyle(Color.black)
+                    Text(viewModel.dialogueText.splitChatacter())
+                        .font(.pretendard(size: fontSize, .regular))
+                        .tracking(-0.015 * fontSize)
+                        .foregroundStyle(.black)
                         .multilineTextAlignment(.leading)
-                        .lineSpacing(1)
                         .padding(.horizontal, 16)
                     
                     Image("DialogButton")
@@ -59,8 +61,7 @@ extension PlantView {
                         .padding(.bottom, 18)
                         .padding(.trailing, 18)
                 }
-                .padding(.vertical, 12)
-                
+                .padding(.vertical, 10)
             }
             .padding(.horizontal, 20)
             .padding(.bottom, 26)


### PR DESCRIPTION
## 📌 Summary
<!-- 이슈 번호
     이슈가 없다면 이 작업을 하게 된 이유 
     작업 내용 요약 -->
- resolve: #61 

<br>

## ✨ Description
- dialogue text 에 `tracking`을 추가해서 자간을 조절하였습니다.
```swift
Text(viewModel.dialogueText.splitChatacter())
      .font(.pretendard(size: fontSize, .regular))
      .tracking(-0.015 * fontSize)
```

- 기존의 단어 기준으로 줄바꿈 되는 문제를 해결하기위해 글자별로 줄바꿈이 될 수 있도록 String extension을 추가하였습니다.
```swift
extension String {
    func splitChatacter() -> String {
        return self.split(separator: "").joined(separator: "\u{200B}")
    }
}
```

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|대사|<img src = "https://github.com/DevTillDie/ForestTori/assets/55949986/f81c3acf-70df-4e8c-acd3-4fe1ef41c37f" width ="250">|

<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
dialogue 말고 다른 부분은 자간을 조절할 필요가 없어서 dialogue text만 tracking으로 자간을 조절하였습니다.
```
