### PR TITLE
feat: add the ability to reselect photos

### DIFF
--- a/ForestTori/ForestTori.xcodeproj/project.pbxproj
+++ b/ForestTori/ForestTori.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		0E1AE71F2B80B9B2001C9A30 /* AutumnCharacter.tsv in Resources */ = {isa = PBXBuildFile; fileRef = 0E1AE71B2B80B9B2001C9A30 /* AutumnCharacter.tsv */; };
 		0E214B5F2BDFC85500558004 /* BottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E214B5E2BDFC85500558004 /* BottomSheet.swift */; };
 		0E214B612BDFD52900558004 /* HistoryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E214B602BDFD52900558004 /* HistoryDetailView.swift */; };
+		0E214B682BE3519400558004 /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 0E214B672BE3519400558004 /* Realm */; };
+		0E214B6A2BE3519400558004 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 0E214B692BE3519400558004 /* RealmSwift */; };
 		0E4AB2282BC90A4C00ADB623 /* ProgressStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4AB2272BC90A4C00ADB623 /* ProgressStyle.swift */; };
 		0E4AB22B2BCD3E7E00ADB623 /* WriteHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4AB22A2BCD3E7E00ADB623 /* WriteHistoryView.swift */; };
 		0E4AB2322BCD66A400ADB623 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4AB2312BCD66A400ADB623 /* ImagePicker.swift */; };
@@ -111,8 +113,6 @@
 		5BBABDE32BCD716800F51288 /* GardenARViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BBABDE22BCD716800F51288 /* GardenARViewModel.swift */; };
 		5BDA85472BCC156400C5C67C /* GardenARView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDA85462BCC156400C5C67C /* GardenARView.swift */; };
 		5BE2F6302BC03AF90049A988 /* GardenScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BE2F62F2BC03AF90049A988 /* GardenScene.swift */; };
-		5BEA73022BD77D8C00BF5ADA /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 5BEA73012BD77D8C00BF5ADA /* Realm */; };
-		5BEA73042BD77D8C00BF5ADA /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 5BEA73032BD77D8C00BF5ADA /* RealmSwift */; };
 		5BEA73062BD77F6E00BF5ADA /* ServiceStateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEA73052BD77F6E00BF5ADA /* ServiceStateViewModel.swift */; };
 		5BEA730C2BD7D17700BF5ADA /* EndingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BEA730B2BD7D17700BF5ADA /* EndingView.swift */; };
 /* End PBXBuildFile section */
@@ -234,8 +234,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5BEA73042BD77D8C00BF5ADA /* RealmSwift in Frameworks */,
-				5BEA73022BD77D8C00BF5ADA /* Realm in Frameworks */,
+				0E214B6A2BE3519400558004 /* RealmSwift in Frameworks */,
+				0E214B682BE3519400558004 /* Realm in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -703,8 +703,8 @@
 			);
 			name = ForestTori;
 			packageProductDependencies = (
-				5BEA73012BD77D8C00BF5ADA /* Realm */,
-				5BEA73032BD77D8C00BF5ADA /* RealmSwift */,
+				0E214B672BE3519400558004 /* Realm */,
+				0E214B692BE3519400558004 /* RealmSwift */,
 			);
 			productName = ForestTori;
 			productReference = 0EF5FE922B4FC02100D64E5E /* ForestTori.app */;
@@ -735,7 +735,7 @@
 			);
 			mainGroup = 0EF5FE892B4FC02100D64E5E;
 			packageReferences = (
-				0E4AB22C2BCD3EBE00ADB623 /* XCRemoteSwiftPackageReference "realm-swift" */,
+				0E214B662BE3519400558004 /* XCRemoteSwiftPackageReference "realm-swift" */,
 			);
 			productRefGroup = 0EF5FE932B4FC02100D64E5E /* Products */;
 			projectDirPath = "";
@@ -1102,7 +1102,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		0E4AB22C2BCD3EBE00ADB623 /* XCRemoteSwiftPackageReference "realm-swift" */ = {
+		0E214B662BE3519400558004 /* XCRemoteSwiftPackageReference "realm-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/realm/realm-swift.git";
 			requirement = {
@@ -1113,14 +1113,14 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		5BEA73012BD77D8C00BF5ADA /* Realm */ = {
+		0E214B672BE3519400558004 /* Realm */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0E4AB22C2BCD3EBE00ADB623 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			package = 0E214B662BE3519400558004 /* XCRemoteSwiftPackageReference "realm-swift" */;
 			productName = Realm;
 		};
-		5BEA73032BD77D8C00BF5ADA /* RealmSwift */ = {
+		0E214B692BE3519400558004 /* RealmSwift */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0E4AB22C2BCD3EBE00ADB623 /* XCRemoteSwiftPackageReference "realm-swift" */;
+			package = 0E214B662BE3519400558004 /* XCRemoteSwiftPackageReference "realm-swift" */;
 			productName = RealmSwift;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/ForestTori/ForestTori.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ForestTori/ForestTori.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "182db11c87d1734fe53a6366b674339f70901a93290bd85def29b63e25e34c43",
   "pins" : [
     {
       "identity" : "realm-core",
@@ -19,5 +20,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
@@ -11,6 +11,7 @@ struct WriteHistoryView: View {
     @StateObject var viewModel = WriteHistoryViewModel()
     @FocusState private var isFocused: Bool
     
+    @State private var isShowSelectImagePopup = false
     @State private var isShowCameraPicker = false
     @State private var isShowPhotoLibraryPicker = false
     
@@ -34,10 +35,16 @@ struct WriteHistoryView: View {
         .fullScreenCover(isPresented: $isShowCameraPicker) {
             ImagePicker(selectedImage: $viewModel.selectedImage, sourceType: .camera)
                 .ignoresSafeArea()
+                .onAppear {
+                    isShowSelectImagePopup = false
+                }
         }
         .sheet(isPresented: $isShowPhotoLibraryPicker) {
             ImagePicker(selectedImage: $viewModel.selectedImage, sourceType: .photoLibrary)
                 .ignoresSafeArea()
+                .onAppear {
+                    isShowSelectImagePopup = false
+                }
         }
         .onTapGesture {
             isFocused = false
@@ -87,9 +94,33 @@ extension WriteHistoryView {
     private var selectImageView: some View {
         VStack {
             if let image = viewModel.selectedImage {
-                Image(uiImage: image)
-                    .resizable()
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                ZStack {
+                    Image(uiImage: image)
+                        .resizable()
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                        .overlay(alignment: .bottomTrailing) {
+                            Button {
+                                withAnimation {
+                                    isShowSelectImagePopup.toggle()
+                                }
+                            } label: {
+                                Image(systemName: "camera")
+                                    .font(.system(size: 14))
+                                    .foregroundStyle(.white)
+                                    .background {
+                                        Circle()
+                                            .fill(.gray50)
+                                            .scaledToFit()
+                                            .padding(-8)
+                                    }
+                                    .padding()
+                            }
+                        }
+                    
+                    if isShowSelectImagePopup {
+                        selectImagePopup
+                    }
+                }
             } else {
                 ZStack {
                     RoundedRectangle(cornerRadius: 8)


### PR DESCRIPTION
## 📌 Summary
<!-- 이슈 번호
     이슈가 없다면 이 작업을 하게 된 이유 
     작업 내용 요약 -->
- resolve: #62

<br>

## ✨ Description
- 사진 재선택 기능 추가
- `WriteHistoryView`에서 사진을 재선택할 수 있는 버튼을 추가했습니다.
- 재선택 버튼을 클릭하면 사진 촬영, 사진 선택 popup이 나타납니다.

```swift
ZStack {
    Image(uiImage: image)
        .resizable()
        .clipShape(RoundedRectangle(cornerRadius: 8))
        .overlay(alignment: .bottomTrailing) {
            Button {
                withAnimation {
                    isShowSelectImagePopup.toggle()
                }
            } label: {
                Image(systemName: "camera")
                    .font(.system(size: 14))
                    .foregroundStyle(.white)
                    .background {
                        Circle()
                            .fill(.gray50)
                            .scaledToFit()
                            .padding(-8)
                    }
                    .padding()
            }
        }
    
    if isShowSelectImagePopup {
        selectImagePopup
    }
}
```

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/DevTillDie/ForestTori/assets/55949986/3b59a06f-3ddf-4ce3-8973-b7d9a144db90" width ="250">|
<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
이 곳에서 리뷰포인트를 작성해주세요.
```
