### PR TITLE
chore: pass user nickname to main dialogue text

### DIFF
--- a/ForestTori/ForestTori/Source/ViewModel/EpilogueViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/EpilogueViewModel.swift
@@ -14,13 +14,7 @@ import SwiftUI
 class EpilogueViewModel: ObservableObject {
     @Published var endingTexts: [[OnboardingText]] = []
     
-    let onboardingViewModel = OnboardingViewModel()
-    let userName: String
-    
-    init() {
-        self.userName = onboardingViewModel.userName
-        setEndingTexts()
-    }
+    private let userName = UserDefaults.standard.value(forKey: "userName") as! String
 }
 
 extension EpilogueViewModel {

--- a/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
@@ -49,6 +49,7 @@ class MainViewModel: ObservableObject {
     private var dialogues = [Dialogue]()
     private var currentDialogueIndex = 0
     private var currentLineIndex = 0
+    private let userName = UserDefaults.standard.value(forKey: "userName") as! String
     
     func setNewPlant(plant: Plant?) {
         self.plant = plant
@@ -131,9 +132,8 @@ class MainViewModel: ObservableObject {
             
             if let dataArr = dataEncoded?.components(separatedBy: "\n").map({$0.components(separatedBy: "\t")}) {
                 for row in dataArr[1..<dataArr.count] {
-                    // TODO: "닉네임"을 db에 저장된 사용자 닉네임으로 변경
                     let lines = Array(row[3...])
-                        .map {$0.replacingOccurrences(of: "(userName)", with: "닉네임")}
+                        .map {$0.replacingOccurrences(of: "(userName)토리", with: userName)}
                         .map {$0.replacingOccurrences(of: "\\n", with: "\n")}
                         .map {$0.replacingOccurrences(of: "\r", with: "")}
                         .filter {!$0.isEmpty}

--- a/ForestTori/ForestTori/Source/ViewModel/OnboardingViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/OnboardingViewModel.swift
@@ -17,7 +17,6 @@ import SwiftUI
 /// - onboardingCompletionText: 온보딩 완료 단계에서 사용하는 텍스트 집합
 class OnboardingViewModel: ObservableObject {
 //    @AppStorage("_isFirstLaunching") var isFirstLaunching = true
-    // TODO: 사용자 관련 변수 분리해서 관리하기
     @AppStorage("userName") var userName = ""
     
     @Published var type: OnboardingType = .greeting


### PR DESCRIPTION
refactor: call user nick name by using user defaults

## 📌 Summary
- resolve: #69 

<br>

## ✨ Description
메인 대사에 사용자 닉네임이 나타나도록 수정하였습니다.
- `OnboardingViewModel`에서 `AppStorage`를 활용하여 저장된 `userName` 값을 `userDefaults`로 호출한 다음,
-  메인 대사의 '닉네임토리'를 `userName` 값으로 대체시켰습니다.
```swift
private let userName = UserDefaults.standard.value(forKey: "userName") as! String

. . .
let lines = Array(row[3...])
                        .map {$0.replacingOccurrences(of: "(userName)토리", with: userName)}
```
- 에필로그 부분도 동일한 방식으로 수정하였습니다.

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|대사|<img src = "https://github.com/DevTillDie/ForestTori/assets/97589973/b8fbf5f4-2093-4ab7-8965-12e0f2385636" width ="250">|

<br>

## 🗒️ Review Point

```
```
