### PR TITLE
fix: add persistence for main

### DIFF
--- a/ForestTori/ForestTori.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ForestTori/ForestTori.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "182db11c87d1734fe53a6366b674339f70901a93290bd85def29b63e25e34c43",
   "pins" : [
     {
       "identity" : "realm-core",
@@ -20,5 +19,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/ForestTori/ForestTori/Source/Utils/Manager/GameManager.swift
+++ b/ForestTori/ForestTori/Source/Utils/Manager/GameManager.swift
@@ -16,7 +16,7 @@ class GameManager: ObservableObject {
     @EnvironmentObject var serviceStateViewModel: ServiceStateViewModel
     @Published var user = User()
     @Published var chapter: Chapter
-    @Published var isSelectPlant = false
+    @AppStorage("isSelectPlant") var isSelectPlant = false
     
     private let dataManager = DataManager()
     

--- a/ForestTori/ForestTori/Source/View/Garden/GardenView.swift
+++ b/ForestTori/ForestTori/Source/View/Garden/GardenView.swift
@@ -19,7 +19,7 @@ struct GardenView: View {
     
     private let noPlantCaption = "아직 다 키운 식물이 없어요."
     private let summerMessage = "여름 하늘은 봄보다 더 높아져서 더 멀리까지 바라볼 수 있는 거 알아?"
-    var totalProgressValue: Float?
+    var totalProgressValue: Double?
     
     var body: some View {
         NavigationView {

--- a/ForestTori/ForestTori/Source/View/Main/MainView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/MainView.swift
@@ -42,6 +42,13 @@ struct MainView: View {
                 showHistoryView
             }
             .ignoresSafeArea()
+            .onAppear {
+                if gameManager.isSelectPlant {
+                    viewModel.setNewPlant(plant: gameManager.user.selectedPlant)
+                } else {
+                    viewModel.setEmptyPot()
+                }
+            }
             .onChange(of: gameManager.isSelectPlant) {
                 if gameManager.isSelectPlant {
                     viewModel.setNewPlant(plant: gameManager.user.selectedPlant)

--- a/ForestTori/ForestTori/Source/View/Main/PlantView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/PlantView.swift
@@ -68,6 +68,7 @@ extension PlantView {
             .onTapGesture {
                 viewModel.showNextDialogue()
             }
+            .hidden(gameManager.isSelectPlant)
     }
     
     private var addNewPlantButton: some View {

--- a/ForestTori/ForestTori/Source/View/ServieStateView.swift
+++ b/ForestTori/ForestTori/Source/View/ServieStateView.swift
@@ -13,7 +13,6 @@ struct ServiceStateView: View {
     
     var body: some View {
         stateBasedView
-//        MainView()
     }
 }
 

--- a/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
@@ -13,6 +13,14 @@ import SwiftUI
 //  - currentLineIndex: dialogues배열 중 currentDialogueIndex에 해당하는 lines 배열에 접근하기 위한 index
 
 class MainViewModel: ObservableObject {
+    @AppStorage("missionDay") var missionDay = 0
+    @AppStorage("currentDialogueIndex") var currentDialogueIndex = 0
+    @AppStorage("isShowDialogueBox") var isShowDialogueBox = true
+    @AppStorage("isShowMissionBox") var isShowMissionBox = false
+    @AppStorage("isTapButton") var isTapDoneButton = false
+    @AppStorage("progressValue") var progressValue = 0.0
+    @AppStorage("totalProgressValue") var totalProgressValue = 0.0
+    
     @Published var plant3DFileName = "Emptypot.scn"
     @Published var plantWidth: CGFloat = 200
     
@@ -20,11 +28,8 @@ class MainViewModel: ObservableObject {
     @Published var missionText = ""
     
     @Published var isShowAddButton = true
-    @Published var isShowDialogueBox = false
     @Published var isShowHistoryView = false
-    @Published var isShowMissionBox = false
     @Published var isShowCompleteMissionView = false
-    @Published var isTapDoneButton = false
     @Published var isDisableDoneButton = false
     @Published var isCompleteMission = false
     
@@ -40,14 +45,10 @@ class MainViewModel: ObservableObject {
     
     @Published var showEnding = false
     
-    @Published var progressValue: Float = 0.0
     @Published var plantName = ""
-    @Published var totalProgressValue: Float = 0.0
     
     private var plant: Plant?
-    private var missionDay = 0
     private var dialogues = [Dialogue]()
-    private var currentDialogueIndex = 0
     private var currentLineIndex = 0
     private let userName = UserDefaults.standard.value(forKey: "userName") as! String
     
@@ -56,16 +57,18 @@ class MainViewModel: ObservableObject {
         
         if let plant = plant {
             getDialogue(plant.characterFileName)
+            
             plant3DFileName = plant.character3DFiles[missionDay]
             plantWidth = 350
             plantName = plant.characterName
             
             isShowAddButton = false
-            isShowDialogueBox = true
             
-            dialogueText = dialogues[currentDialogueIndex].lines[currentLineIndex]
+            if currentLineIndex < dialogues[currentDialogueIndex].lines.count {
+                dialogueText = dialogues[currentDialogueIndex].lines[currentLineIndex]
+            }
+
             missionText = plant.missions[missionDay].content
-            currentLineIndex += 1
         }
     }
     
@@ -80,7 +83,6 @@ class MainViewModel: ObservableObject {
         missionText = ""
         
         isShowAddButton = true
-        isShowDialogueBox = false
         isShowMissionBox = false
         isTapDoneButton = false
         isDisableDoneButton = false
@@ -109,8 +111,8 @@ class MainViewModel: ObservableObject {
     func completMission() {
         currentDialogueIndex += 1
         currentLineIndex = 0
-        progressValue = (Float(missionDay + 1)/Float(plant?.totalDay ?? 0)) * 100
-        totalProgressValue += (1 / Float(plant?.totalDay ?? 1)) * 25
+        progressValue = (Double(missionDay + 1)/Double(plant?.totalDay ?? 0)) * 100
+        totalProgressValue += (1 / Double(plant?.totalDay ?? 1)) * 25
         
         isShowDialogueBox = true
         isDisableDoneButton = true
@@ -154,6 +156,7 @@ class MainViewModel: ObservableObject {
     
     private func nextDay() {
         missionDay += 1
+        isTapDoneButton = false
 
         if let plant = plant {
             if missionDay == plant.totalDay {
@@ -161,7 +164,6 @@ class MainViewModel: ObservableObject {
                     showEnding = true
                 } else {
                     isCompleteMission = true
-                    isShowDialogueBox = false
                     isShowMissionBox = false
                 }
             } else {

--- a/ForestTori/ForestTori/Source/ViewModel/ServiceStateViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/ServiceStateViewModel.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 class ServiceStateViewModel: ObservableObject {
-    // TODO: 기능 통합 완료 후, .onboarding으로 수정
     @AppStorage("serviceState") var state: ServiceState = .onboarding
     
     /// 서비스 상태 유형


### PR DESCRIPTION
## 📌 Summary
<!-- 이슈 번호
     이슈가 없다면 이 작업을 하게 된 이유 
     작업 내용 요약 -->
- resolve: #70 

<br>

## ✨ Description
미션 진행 과정이 유지될 수 있도록 코드를 수정하였습니다.
- `@AppStorage` 변수로 변경하여 미션 진행 과정이 유지될 수 있도록 하였습니다.
```swift
// MainViewModel.swift
@AppStorage("missionDay") var missionDay = 0
@AppStorage("currentDialogueIndex") var currentDialogueIndex = 0
@AppStorage("isShowDialogueBox") var isShowDialogueBox = true
@AppStorage("isShowMissionBox") var isShowMissionBox = false
@AppStorage("isTapButton") var isTapDoneButton = false
@AppStorage("progressValue") var progressValue = 0.0
@AppStorage("totalProgressValue") var totalProgressValue = 0.0

// GameManager.swift
@AppStorage("isSelectPlant") var isSelectPlant = false
```

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|미션 플레이 유지|<img src = "https://github.com/DevTillDie/ForestTori/assets/97589973/8c96017e-4969-4279-a003-bd2ae0ad9fb9" width ="250">|

<br>

## 🗒️ Review Point
```
플레이 유지에 필요한 변수들이 대부분 @AppStorage에서 지원하는 타입들이어서,
@AppStorage 적용해서 빠르게 수정해 보았습니다.

미션을 이어서 확인할 수 있도록 하였고,
대사의 경우, 대사 묶음(tsv 기준 1 열) 중 첫 번째로 돌아가서 다시 시작하도록 하였습니다.
```
