### PR TITLE
chore: modify scene contrast for plant object

### DIFF
--- a/ForestTori/ForestTori/Source/View/Main/PlantPotView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/PlantPotView.swift
@@ -26,7 +26,7 @@ struct PlantPotView: UIViewRepresentable {
         sceneView.scene?.rootNode.scale = SCNVector3(x: 0.8, y: 0.8, z: 0.8)
         
         sceneView.scene?.rootNode.addChildNode(lightNode)
-        sceneView.pointOfView?.camera?.contrast = -5
+        sceneView.pointOfView?.camera?.contrast = -3
         
         sceneView.autoenablesDefaultLighting = true
         sceneView.allowsCameraControl = true
@@ -54,7 +54,7 @@ struct PlantPotView: UIViewRepresentable {
             scnView.scene?.rootNode.name = sceneViewName
             
             scnView.scene?.rootNode.addChildNode(lightNode)
-            scnView.pointOfView?.camera?.contrast = -5
+            scnView.pointOfView?.camera?.contrast = -3
         }
     }
     


### PR DESCRIPTION
## 📌 Summary
- resolve: #80 

<br>

## ✨ Description
현재 대비값에서 식물 오브젝트의 음영이 뭉개지는 현상이 발견하여, 대비값을 변경하였습니다.
- 기존) -5 ➡️ 현재) -3

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|대비값(前)|<img src = "https://github.com/DevTillDie/ForestTori/assets/97589973/520ba322-37c4-4656-8bcb-645ef1060e08" width ="250">|
|대비값(后)|<img src = "https://github.com/DevTillDie/ForestTori/assets/97589973/97d1081c-6d23-46ab-a4eb-e36eec459713" width ="250">|
