### PR TITLE
feat: add notification manager

### DIFF
--- a/ForestTori/ForestTori.xcodeproj/project.pbxproj
+++ b/ForestTori/ForestTori.xcodeproj/project.pbxproj
@@ -32,7 +32,6 @@
 		0E62B72C2BFB0C1C0011B34E /* Cottontree1.scn in Resources */ = {isa = PBXBuildFile; fileRef = 0E62B72B2BFB0C1C0011B34E /* Cottontree1.scn */; };
 		0E62B72E2BFB0C240011B34E /* Cottontree2.scn in Resources */ = {isa = PBXBuildFile; fileRef = 0E62B72D2BFB0C240011B34E /* Cottontree2.scn */; };
 		0E62B7302BFB0C2B0011B34E /* Cottontree3.scn in Resources */ = {isa = PBXBuildFile; fileRef = 0E62B72F2BFB0C2B0011B34E /* Cottontree3.scn */; };
-		0E62B73D2BFB178D0011B34E /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 0E62B73C2BFB178D0011B34E /* Realm */; };
 		0E62B73F2BFB178D0011B34E /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 0E62B73E2BFB178D0011B34E /* RealmSwift */; };
 		0E62B7412BFB184C0011B34E /* UnevenRoundedRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E62B7402BFB184C0011B34E /* UnevenRoundedRectangle.swift */; };
 		0E62B76F2BFCB68F0011B34E /* SpringPlants.tsv in Resources */ = {isa = PBXBuildFile; fileRef = 0E62B76A2BFCB68F0011B34E /* SpringPlants.tsv */; };
@@ -82,6 +81,7 @@
 		0EF5FE9A2B4FC02200D64E5E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0EF5FE992B4FC02200D64E5E /* Assets.xcassets */; };
 		0EF5FE9D2B4FC02200D64E5E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0EF5FE9C2B4FC02200D64E5E /* Preview Assets.xcassets */; };
 		0EF5FEA52B4FC0E700D64E5E /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 0EF5FEA42B4FC0E700D64E5E /* .swiftlint.yml */; };
+		5B1676E12C384B16009DA49F /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1676E02C384B16009DA49F /* NotificationManager.swift */; };
 		5B6351062BED17AF00A1C6AB /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E214B642BE34B5A00558004 /* String+.swift */; };
 		5B68A4262B8454790004E89A /* ServieStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B68A4252B8454790004E89A /* ServieStateView.swift */; };
 		5B68A4352B845DFE0004E89A /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E1AE6FD2B7E185B001C9A30 /* Font+.swift */; };
@@ -198,6 +198,7 @@
 		0EF5FE992B4FC02200D64E5E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		0EF5FE9C2B4FC02200D64E5E /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		0EF5FEA42B4FC0E700D64E5E /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		5B1676E02C384B16009DA49F /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		5B68A4252B8454790004E89A /* ServieStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServieStateView.swift; sourceTree = "<group>"; };
 		5B68A4362B845E200004E89A /* View+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 		5B72DDC72B91BA8B002EA734 /* EpilogueViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpilogueViewModel.swift; sourceTree = "<group>"; };
@@ -240,7 +241,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				0E62B73F2BFB178D0011B34E /* RealmSwift in Frameworks */,
-				0E62B73D2BFB178D0011B34E /* Realm in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -287,6 +287,7 @@
 				5BA395432B7252C00019A545 /* GameManager.swift */,
 				5BA931182B6260CC00F48AF1 /* DataManager.swift */,
 				0E4AB2352BCD70F400ADB623 /* RealmManager.swift */,
+				5B1676E02C384B16009DA49F /* NotificationManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -373,13 +374,6 @@
 				0E62B7402BFB184C0011B34E /* UnevenRoundedRectangle.swift */,
 			);
 			path = Component;
-			sourceTree = "<group>";
-		};
-		0EADEAB12B7DF5060036D190 /* Modifier */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Modifier;
 			sourceTree = "<group>";
 		};
 		0EADEAB42B7DF5140036D190 /* Extension */ = {
@@ -595,7 +589,6 @@
 				0E5AA5482BA17F3B00727C79 /* Manager */,
 				0EADEAAE2B7DF4E90036D190 /* Component */,
 				0EADEAB42B7DF5140036D190 /* Extension */,
-				0EADEAB12B7DF5060036D190 /* Modifier */,
 				0E4AB23E2BD0FD6400ADB623 /* KeyboardHandler.swift */,
 			);
 			path = Utils;
@@ -712,7 +705,6 @@
 			);
 			name = ForestTori;
 			packageProductDependencies = (
-				0E62B73C2BFB178D0011B34E /* Realm */,
 				0E62B73E2BFB178D0011B34E /* RealmSwift */,
 			);
 			productName = ForestTori;
@@ -877,6 +869,7 @@
 				0EF5FE962B4FC02100D64E5E /* ForestToriApp.swift in Sources */,
 				0E9532FA2BDCB9580081DCE0 /* HistoryView.swift in Sources */,
 				0E4AB23F2BD0FD6400ADB623 /* KeyboardHandler.swift in Sources */,
+				5B1676E12C384B16009DA49F /* NotificationManager.swift in Sources */,
 				5B72DDC82B91BA8B002EA734 /* EpilogueViewModel.swift in Sources */,
 				5B9152A82B84402C0068418F /* OnboardingTextBox.swift in Sources */,
 				5BA3955E2B7E377D0019A545 /* OnboardingGreetingView.swift in Sources */,
@@ -1131,11 +1124,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		0E62B73C2BFB178D0011B34E /* Realm */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 0E62B73B2BFB178D0011B34E /* XCRemoteSwiftPackageReference "realm-swift" */;
-			productName = Realm;
-		};
 		0E62B73E2BFB178D0011B34E /* RealmSwift */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 0E62B73B2BFB178D0011B34E /* XCRemoteSwiftPackageReference "realm-swift" */;

--- a/ForestTori/ForestTori.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ForestTori/ForestTori.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,12 @@
 {
-  "originHash" : "182db11c87d1734fe53a6366b674339f70901a93290bd85def29b63e25e34c43",
   "pins" : [
     {
       "identity" : "realm-core",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/realm-core.git",
       "state" : {
-        "revision" : "4d815c6e6883bfdcb67cf755d0f0f29a4b399ea7",
-        "version" : "14.5.2"
+        "revision" : "f889f79a2301208fd9d322d07abfc883b8f2046c",
+        "version" : "14.10.2"
       }
     },
     {
@@ -16,9 +15,9 @@
       "location" : "https://github.com/realm/realm-swift.git",
       "state" : {
         "branch" : "master",
-        "revision" : "3a9586b62042a4e010f3d3439b67a4779017fe07"
+        "revision" : "9f850cb56f90ea14e840b051b7e2318ac5d7b16d"
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/ForestTori/ForestTori/Source/Utils/Manager/NotificationManager.swift
+++ b/ForestTori/ForestTori/Source/Utils/Manager/NotificationManager.swift
@@ -1,0 +1,61 @@
+//
+//  NotificationManager.swift
+//  ForestTori
+//
+//  Created by Nayeon Kim on 7/6/24.
+//
+
+import SwiftUI
+import UserNotifications
+
+class NotificationManager: ObservableObject {
+    @Published var isNotificationSet = false
+    
+    static let instance = NotificationManager()
+    private init() { }
+    
+    func requestAuthorization() {
+        let options: UNAuthorizationOptions = [.alert, .sound, .badge]
+        UNUserNotificationCenter.current().requestAuthorization(options: options) { success, error in
+            DispatchQueue.main.async {
+                if let error {
+                    print("Request Notificaiton Authorization ERROR: \(error)")
+                } else if success {
+                    self.isNotificationSet = true
+                    print("permission granted")
+                } else {
+                    self.isNotificationSet = true
+                    print("permission denied")
+                }
+            }
+        }
+    }
+    
+    func scheduleNotification(for plantName: String) {
+        // 선택 식물이 바뀌면 과거에 설정된 알림 대기를 모두 지움
+        UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+        
+        let times: [(hour: Int, minute: Int)] = [(10, 0), (20, 0)]
+        for time in times {
+            let content = UNMutableNotificationContent()
+            content.title = "숲토리"
+            content.body = "\(plantName)이/가 토리를 기다리고 있어요:)\n오늘 미션을 수행해서 \(plantName)을/를 키워보아요!"
+            content.sound = UNNotificationSound.default
+            
+            var dateComponents = DateComponents()
+            dateComponents.hour = time.hour
+            dateComponents.minute = time.minute
+            
+            let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
+            let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
+            
+            UNUserNotificationCenter.current().add(request) { error in
+                if let error {
+                    print("Request Scheduled Notification ERROR: \(error)")
+                } else {
+                    print("notification scheduled")
+                }
+            }
+        }
+    }
+}

--- a/ForestTori/ForestTori/Source/View/Main/MainView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/MainView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct MainView: View {
     @EnvironmentObject var gameManager: GameManager
+    @EnvironmentObject var notificationManager: NotificationManager
     @EnvironmentObject var serviceStateViewModel: ServiceStateViewModel
     @StateObject var viewModel = MainViewModel()
     @StateObject private var keyboardHandler = KeyboardHandler()
@@ -60,6 +61,11 @@ struct MainView: View {
                 gameManager.completeMission()
                 withAnimation {
                     serviceStateViewModel.state = .ending
+                }
+            }
+            .onChange(of: gameManager.user.selectedPlant?.characterName) { newPlantName in
+                if let newPlantName {
+                    notificationManager.scheduleNotification(for: newPlantName)
                 }
             }
         }

--- a/ForestTori/ForestTori/Source/View/Onboarding/OnboardingGreetingView.swift
+++ b/ForestTori/ForestTori/Source/View/Onboarding/OnboardingGreetingView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct OnboardingGreetingView: View {
+    @EnvironmentObject private var notificationManager: NotificationManager
     @EnvironmentObject var onboardingViewModel: OnboardingViewModel
     
     @State var isHidden = false
@@ -44,8 +45,10 @@ struct OnboardingGreetingView: View {
             OnboardingSkipButton(action: onboardingViewModel.moveToOnboardingNamingView)
                 .hidden(isHidden)
         }
-        .onAppear {
-            increaseTextIndex()
+        .onChange(of: notificationManager.isNotificationSet) { newValue in
+            if newValue {
+                increaseTextIndex()
+            }
         }
     }
 }

--- a/ForestTori/ForestTori/Source/View/Onboarding/OnboardingView.swift
+++ b/ForestTori/ForestTori/Source/View/Onboarding/OnboardingView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct OnboardingView: View {
+    @EnvironmentObject private var notificationManager: NotificationManager
     @EnvironmentObject var serviceStateViewModel: ServiceStateViewModel
     @StateObject var onboardingViewModel = OnboardingViewModel()
     
@@ -31,6 +32,7 @@ extension OnboardingView {
         switch onboardingViewModel.type {
         case .greeting:
             OnboardingGreetingView()
+                .environmentObject(notificationManager)
                 .environmentObject(onboardingViewModel)
         case .introduction:
             OnboardingIntroductionView()

--- a/ForestTori/ForestTori/Source/View/ServieStateView.swift
+++ b/ForestTori/ForestTori/Source/View/ServieStateView.swift
@@ -9,10 +9,14 @@ import SwiftUI
 
 struct ServiceStateView: View {
     @StateObject var gameManager = GameManager()
+    @StateObject private var notificationManager = NotificationManager.instance
     @StateObject var serviceStateViewModel = ServiceStateViewModel()
     
     var body: some View {
         stateBasedView
+            .onAppear {
+                notificationManager.requestAuthorization()
+            }
     }
 }
 
@@ -23,11 +27,13 @@ extension ServiceStateView {
         switch serviceStateViewModel.state {
         case .onboarding:
             OnboardingView()
+                .environmentObject(notificationManager)
                 .environmentObject(serviceStateViewModel)
         case .main:
             MainView()
                 .transition(.move(edge: .trailing))
                 .environmentObject(gameManager)
+                .environmentObject(notificationManager)
                 .environmentObject(serviceStateViewModel)
         case .ending:
             EndingView()


### PR DESCRIPTION
chore: allow onboarding view transition after notification setting

## 📌 Summary
- resolve: #90 

<br>

## ✨ Description
- `NotificationManager`를 추가하여 알림 권한 설정과 알림 스케줄링을 구현하였습니다.
- 온보딩 시작 전, 권한을 요청하게 하였습니다.
  - 권한 허용 여부와 상관없이 앱을 사용할 수 있도록 하였습니다.
  - 또한, 권한을 허용하기 전에는 온보딩 화면이 자동으로 전환되지 않도록 하였습니다.
 - 식물 이름이 알림에 사용되기 때문에, 알림은 식물을 선택한 이후에 스케줄링되도록 구현하였습니다.
   - 또한, 선택한 식물이 바뀌면 기존에 대기 중이던 알림은 모두 삭제되도록 하였습니다. 

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|권한 설정|<img src = "https://github.com/user-attachments/assets/6902dde4-6067-41c2-886b-666cfbd2408b" width ="250">|
|알림|<img src = "https://github.com/user-attachments/assets/c7d56eec-e1f4-45f1-acfd-cb953b8114ce" width ="250">|

<br>

## 🗒️ Review Point
```
위 사진에 등장하는 알림 문구는 테스트용으로 확인한 부분이며, 현재는 완성된 문구로 설정되어 있습니다.

코드 확인하시고, 불필요한 부분이나 개선할 수 있는 부분 있으면 코멘트 남겨주세요:-)
```
