### PR TITLE
design: modify history view ui

### DIFF
--- a/ForestTori/ForestTori/Source/View/Garden/GardenView.swift
+++ b/ForestTori/ForestTori/Source/View/Garden/GardenView.swift
@@ -16,7 +16,7 @@ struct GardenView: View {
     @State private var isShowHistoryView = false
     @State private var showHistoryDetail = false
     @State private var selectedPlant: Plant?
-    @State private var selectedHistory: (image: UIImage, record: String)?
+    @State private var selectedHistory: (image: UIImage, date: String, record: String)?
     
     private let noPlantCaption = "아직 다 키운 식물이 없어요."
     private let summerMessage = "여름 하늘은 봄보다 더 높아져서 더 멀리까지 바라볼 수 있는 거 알아?"
@@ -59,7 +59,7 @@ struct GardenView: View {
                 
                 showHistoryView
                 
-                showDetailHistory
+//                showDetailHistory
             }
             .ignoresSafeArea()
             .navigationBarBackButtonHidden(true)
@@ -179,38 +179,38 @@ extension GardenView {
         .animation(.interactiveSpring(), value: isShowHistoryView)
     }
     
-    private var showDetailHistory: some View {
-        ZStack {
-            if let history = selectedHistory {
-                if showHistoryDetail {
-                    Color.black.opacity(0.4)
-                        .ignoresSafeArea()
-                        .onTapGesture {
-                            withAnimation {
-                                showHistoryDetail = false
-                                selectedHistoryIndex = nil
-                            }
-                        }
-                        .transition(.opacity)
-                    
-                    HistoryDetailView(
-                        selectedHistoryIndex: $selectedHistoryIndex,
-                        isShowHistoryDetailView: $showHistoryDetail,
-                        image: history.image,
-                        record: history.record
-                    )
-                    .padding(.vertical)
-                    .transition(.move(edge: .bottom))
-                    .frame(width: UIScreen.main.bounds.width * 0.9, height: UIScreen.main.bounds.height * 0.6)
-                    .background(
-                        RoundedRectangle(cornerRadius: 10)
-                            .fill(.white)
-                    )
-                }
-            }
-        }
-        .animation(.easeInOut(duration: 0.2), value: showHistoryDetail)
-    }
+//    private var showDetailHistory: some View {
+//        ZStack {
+//            if let history = selectedHistory {
+//                if showHistoryDetail {
+//                    Color.black.opacity(0.4)
+//                        .ignoresSafeArea()
+//                        .onTapGesture {
+//                            withAnimation {
+//                                showHistoryDetail = false
+//                                selectedHistoryIndex = nil
+//                            }
+//                        }
+//                        .transition(.opacity)
+//                    
+////                    HistoryDetailView(
+////                        selectedHistoryIndex: $selectedHistoryIndex,
+////                        isShowHistoryDetailView: $showHistoryDetail,
+////                        image: history.image,
+////                        record: history.record
+////                    )
+//                    .padding(.vertical)
+//                    .transition(.move(edge: .bottom))
+//                    .frame(width: UIScreen.main.bounds.width * 0.9, height: UIScreen.main.bounds.height * 0.6)
+//                    .background(
+//                        RoundedRectangle(cornerRadius: 10)
+//                            .fill(.white)
+//                    )
+//                }
+//            }
+//        }
+//        .animation(.easeInOut(duration: 0.2), value: showHistoryDetail)
+//    }
 }
 
 // MARK: - ARButton

--- a/ForestTori/ForestTori/Source/View/Garden/GardenView.swift
+++ b/ForestTori/ForestTori/Source/View/Garden/GardenView.swift
@@ -58,8 +58,6 @@ struct GardenView: View {
                 }
                 
                 showHistoryView
-                
-//                showDetailHistory
             }
             .ignoresSafeArea()
             .navigationBarBackButtonHidden(true)
@@ -178,39 +176,6 @@ extension GardenView {
         .ignoresSafeArea()
         .animation(.interactiveSpring(), value: isShowHistoryView)
     }
-    
-//    private var showDetailHistory: some View {
-//        ZStack {
-//            if let history = selectedHistory {
-//                if showHistoryDetail {
-//                    Color.black.opacity(0.4)
-//                        .ignoresSafeArea()
-//                        .onTapGesture {
-//                            withAnimation {
-//                                showHistoryDetail = false
-//                                selectedHistoryIndex = nil
-//                            }
-//                        }
-//                        .transition(.opacity)
-//                    
-////                    HistoryDetailView(
-////                        selectedHistoryIndex: $selectedHistoryIndex,
-////                        isShowHistoryDetailView: $showHistoryDetail,
-////                        image: history.image,
-////                        record: history.record
-////                    )
-//                    .padding(.vertical)
-//                    .transition(.move(edge: .bottom))
-//                    .frame(width: UIScreen.main.bounds.width * 0.9, height: UIScreen.main.bounds.height * 0.6)
-//                    .background(
-//                        RoundedRectangle(cornerRadius: 10)
-//                            .fill(.white)
-//                    )
-//                }
-//            }
-//        }
-//        .animation(.easeInOut(duration: 0.2), value: showHistoryDetail)
-//    }
 }
 
 // MARK: - ARButton

--- a/ForestTori/ForestTori/Source/View/Garden/HistoryDetailView.swift
+++ b/ForestTori/ForestTori/Source/View/Garden/HistoryDetailView.swift
@@ -10,9 +10,10 @@ import SwiftUI
 struct HistoryDetailView: View {
     @Binding var selectedHistoryIndex: Int?
     @Binding var isShowHistoryDetailView: Bool
+    @Binding var selectedHistory: (image: UIImage, date: String, record: String)?
     
-    var image: UIImage
-    var record: String
+//    var image: UIImage
+//    var record: String
     
     var body: some View {
         VStack {
@@ -29,35 +30,44 @@ struct HistoryDetailView: View {
 
 extension HistoryDetailView {
     private var viewHeader: some View {
-        HStack {
-            Button {
-                withAnimation {
-                    selectedHistoryIndex = nil
-                    isShowHistoryDetailView = false
+        VStack {
+            HStack {
+                Button {
+                    withAnimation {
+                        selectedHistoryIndex = nil
+                        isShowHistoryDetailView = false
+                    }
+                } label: {
+                    Text(Image(systemName: "chevron.backward"))
+                        .bold()
+                        .foregroundStyle(.gray40)
                 }
-            } label: {
-                Image(systemName: "xmark")
-                    .foregroundStyle(.redPrimary)
+                
+                Spacer()
+                
+                Text(selectedHistory?.date ?? "0000.00.00")
+                    .font(.subtitleL)
+                
+                Spacer()
+                
             }
+            .padding(.horizontal, 8)
+            .padding(.top, 11)
+            .padding(.bottom, 6)
             
-            Spacer()
-            
-            Text("성장일지")
-                .font(.subtitleL)
-            
-            Spacer()
-            
+            Rectangle()
+                .fill(.gray30)
+                .frame(height: 0.33)
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 8)
     }
     
     private var imageView: some View {
-        Image(uiImage: image)
+        Image(uiImage: selectedHistory?.image ?? .onboardingFrezia)
             .resizable()
             .clipShape(RoundedRectangle(cornerRadius: 8))
-            .aspectRatio(5/3, contentMode: .fit)
+            .aspectRatio(1, contentMode: .fill)
             .padding(.horizontal)
+            .padding(.vertical)
     }
     
     private var recordView: some View {
@@ -68,7 +78,7 @@ extension HistoryDetailView {
                     .stroke(.brownSecondary, lineWidth: 2)
             }
             .overlay(alignment: .topLeading) {
-                Text(record.splitCharacter())
+                Text(selectedHistory?.record.splitCharacter() ?? "내용 없음")
                     .font(.bodyM)
                     .foregroundStyle(.gray50)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/ForestTori/ForestTori/Source/View/Garden/HistoryView.swift
+++ b/ForestTori/ForestTori/Source/View/Garden/HistoryView.swift
@@ -13,7 +13,7 @@ struct HistoryView: View {
     @Binding var selectedHistoryIndex: Int?
     @Binding var isShowHistoryDetail: Bool
     @Binding var plant: Plant?
-    @Binding var selectedHistory: (image: UIImage, record: String)?
+    @Binding var selectedHistory: (image: UIImage, date: String, record: String)?
     
     var body: some View {
         if let plant = plant {
@@ -44,6 +44,9 @@ struct HistoryView: View {
             }
             .onAppear {
                 viewModel.loadHistoryData(plantName: plant.characterName)
+            }
+            .fullScreenCover(isPresented: $isShowHistoryDetail) {
+                HistoryDetailView(selectedHistoryIndex: $selectedHistoryIndex, isShowHistoryDetailView: $isShowHistoryDetail, selectedHistory: $selectedHistory)
             }
         }
     }
@@ -80,7 +83,7 @@ extension HistoryView {
                         selectedHistoryIndex = index
                         if let imageName = history.imageData,
                            let image = UIImage(data: imageName) {
-                            selectedHistory = (image, history.text)
+                            selectedHistory = (image, history.date, history.text)
                             isShowHistoryDetail = true
                         }
                     }

--- a/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
@@ -27,12 +27,24 @@ struct WriteHistoryView: View {
         VStack {
             hisoryViewHeader
             
-            selectImageView
-                .aspectRatio(1, contentMode: .fill)
-                .padding(.horizontal)
-                .padding(.vertical)
-            
-            writeHistoryView
+            ScrollViewReader { proxy in
+                ScrollView(showsIndicators: false) {
+                    selectImageView
+                        .aspectRatio(1, contentMode: .fill)
+                        .padding(.horizontal)
+                        .padding(.vertical)
+                    
+                    writeHistoryView
+                        .id("writeHistoryView")
+                        .onChange(of: isFocused) { focused in
+                            if focused {
+                                withAnimation {
+                                    proxy.scrollTo("writeHistoryView", anchor: .bottom)
+                                }
+                            }
+                        }
+                }
+            }
         }
         .fullScreenCover(isPresented: $isShowCameraPicker) {
             ImagePicker(selectedImage: $viewModel.selectedImage, sourceType: .camera)
@@ -146,6 +158,7 @@ extension WriteHistoryView {
     private var writeHistoryView: some View {
         RoundedRectangle(cornerRadius: 5)
             .fill(Color.gray10)
+            .frame(height: 298)
             .overlay {
                 RoundedRectangle(cornerRadius: 5)
                     .stroke(.brownSecondary, lineWidth: 2)
@@ -178,6 +191,7 @@ extension WriteHistoryView {
                 .padding()
             }
             .padding(.horizontal)
+            .padding(.bottom, 26)
             .onTapGesture {
                 isFocused = true
             }

--- a/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct WriteHistoryView: View {
     @StateObject var viewModel = WriteHistoryViewModel()
+    @EnvironmentObject var keyboardHandler: KeyboardHandler
     @FocusState private var isFocused: Bool
     
     @State private var isShowSelectImagePopup = false
@@ -27,8 +28,9 @@ struct WriteHistoryView: View {
             hisoryViewHeader
             
             selectImageView
-                .aspectRatio(5/3, contentMode: .fit)
+                .aspectRatio(1, contentMode: .fill)
                 .padding(.horizontal)
+                .padding(.vertical)
             
             writeHistoryView
         }
@@ -59,36 +61,46 @@ struct WriteHistoryView: View {
 
 extension WriteHistoryView {
     private var hisoryViewHeader: some View {
-        HStack {
-            Button {
-                withAnimation {
-                    isShowHistoryView = false
-                    isTapDoneButton = false
+        VStack {
+            HStack {
+                Button {
+                    withAnimation {
+                        isShowHistoryView = false
+                        isTapDoneButton = false
+                    }
+                } label: {
+                    Text(Image(systemName: "chevron.backward"))
+                        .bold()
+                        .foregroundStyle(.gray40)
                 }
-            } label: {
-                Image(systemName: "xmark")
-                    .foregroundStyle(.redPrimary)
+                
+                Spacer()
+                
+                Text("성장일지")
+                    .font(.subtitleL)
+                
+                Spacer()
+                
+                Button {
+                    viewModel.saveHistory()
+                    isComplete = true
+                } label: {
+                    Text("완료")
+                        .font(.subtitleM)
+                        .bold()
+                        .foregroundStyle(viewModel.isCompleteButtonDisable ? .gray30 : .greenSecondary)
+                }
+                .disabled(viewModel.isCompleteButtonDisable)
             }
+            .padding(.leading, 8)
+            .padding(.trailing, 16)
+            .padding(.top, 11)
+            .padding(.bottom, 6)
             
-            Spacer()
-            
-            Text("성장일지")
-                .font(.subtitleL)
-            
-            Spacer()
-            
-            Button {
-                viewModel.saveHistory()
-                isComplete = true
-            } label: {
-                Text("완료")
-                    .font(.subtitleM)
-                    .foregroundStyle(viewModel.isCompleteButtonDisable ? .gray30 : .greenSecondary)
-            }
-            .disabled(viewModel.isCompleteButtonDisable)
+            Rectangle()
+                .fill(.gray30)
+                .frame(height: 0.33)
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 8)
     }
     
     private var selectImageView: some View {

--- a/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
@@ -163,23 +163,32 @@ extension WriteHistoryView {
                 RoundedRectangle(cornerRadius: 5)
                     .stroke(.brownSecondary, lineWidth: 2)
             }
-            .overlay(alignment: .top) {
-                TextEditor(
-                    text: Binding(
-                        get: {viewModel.todayHistory},
-                        set: { newValue, _ in
-                            if newValue.lastIndex(of: "\n") != nil {
-                                isFocused = false
-                            } else {
-                                viewModel.todayHistory = newValue
-                            }
-                        })
-                )
+            .overlay(alignment: .center) {
+                    TextEditor(
+                        text: Binding(
+                            get: {viewModel.todayHistory},
+                            set: { newValue, _ in
+                                if newValue.lastIndex(of: "\n") != nil {
+                                    isFocused = false
+                                } else {
+                                    viewModel.todayHistory = newValue
+                                }
+                            })
+                    )
+                    .padding(-8)
                 .overlay(alignment: .topLeading) {
                     Text(placeHolder)
                         .foregroundStyle(viewModel.todayHistory.isEmpty ? .gray30 : .clear)
-                        .padding(.vertical, 8)
-                        .padding(.horizontal, 4)
+                        .padding(.horizontal, -4)
+                }
+                .overlay(alignment: .bottomTrailing) {
+                    Text("\(viewModel.todayHistory.count) / 300")
+                        .foregroundStyle(.gray30)
+                        .onChange(of: viewModel.todayHistory) { newValue in
+                            if newValue.count > 300 {
+                                viewModel.todayHistory = String(newValue.prefix(300))
+                            }
+                        }
                 }
                 .transparentScrolling()
                 .focused($isFocused)

--- a/ForestTori/ForestTori/Source/View/Main/MainView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/MainView.swift
@@ -50,6 +50,7 @@ struct MainView: View {
                     isTapDoneButton: $viewModel.isTapDoneButton,
                     plantName: viewModel.plantName
                 )
+                .environmentObject(keyboardHandler)
             }
             .onAppear {
                 if gameManager.isSelectPlant {

--- a/ForestTori/ForestTori/Source/View/Main/MainView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/MainView.swift
@@ -40,9 +40,17 @@ struct MainView: View {
                 
                 showCompleteMission
                 
-                showHistoryView
+//                showHistoryView
             }
             .ignoresSafeArea()
+            .fullScreenCover(isPresented: $viewModel.isShowHistoryView) {
+                WriteHistoryView(
+                    isComplete: $viewModel.isCompleteTodayMission,
+                    isShowHistoryView: $viewModel.isShowHistoryView,
+                    isTapDoneButton: $viewModel.isTapDoneButton,
+                    plantName: viewModel.plantName
+                )
+            }
             .onAppear {
                 if gameManager.isSelectPlant {
                     viewModel.setNewPlant(plant: gameManager.user.selectedPlant)
@@ -63,11 +71,11 @@ struct MainView: View {
                     serviceStateViewModel.state = .ending
                 }
             }
-            .onChange(of: gameManager.user.selectedPlant?.characterName) { newPlantName in
-                if let newPlantName {
-                    notificationManager.scheduleNotification(for: newPlantName)
-                }
-            }
+//            .onChange(of: gameManager.user.selectedPlant?.characterName) { newPlantName in
+//                if let newPlantName {
+//                    notificationManager.scheduleNotification(for: newPlantName)
+//                }
+//            }
         }
     }
 }

--- a/ForestTori/ForestTori/Source/View/Main/MainView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/MainView.swift
@@ -39,8 +39,6 @@ struct MainView: View {
                 showSelectPlantView
                 
                 showCompleteMission
-                
-//                showHistoryView
             }
             .ignoresSafeArea()
             .fullScreenCover(isPresented: $viewModel.isShowHistoryView) {
@@ -72,11 +70,11 @@ struct MainView: View {
                     serviceStateViewModel.state = .ending
                 }
             }
-//            .onChange(of: gameManager.user.selectedPlant?.characterName) { newPlantName in
-//                if let newPlantName {
-//                    notificationManager.scheduleNotification(for: newPlantName)
-//                }
-//            }
+            .onChange(of: gameManager.user.selectedPlant?.characterName) { newPlantName in
+                if let newPlantName {
+                    notificationManager.scheduleNotification(for: newPlantName)
+                }
+            }
         }
     }
 }
@@ -186,39 +184,6 @@ extension MainView {
             }
         }
         .hidden(viewModel.isShowCompleteMissionView)
-    }
-    
-    private var showHistoryView: some View {
-        ZStack {
-            if viewModel.isShowHistoryView {
-                Color.black.opacity(0.4)
-                    .ignoresSafeArea()
-                    .onTapGesture {
-                        withAnimation {
-                            viewModel.isShowHistoryView = false
-                            viewModel.isTapDoneButton = false
-                        }
-                    }
-                    .transition(.opacity)
-                
-                WriteHistoryView(
-                    isComplete: $viewModel.isCompleteTodayMission,
-                    isShowHistoryView: $viewModel.isShowHistoryView,
-                    isTapDoneButton: $viewModel.isTapDoneButton,
-                    plantName: viewModel.plantName
-                )
-                .padding(.vertical)
-                .transition(.move(edge: .bottom))
-                .frame(width: UIScreen.main.bounds.width * 0.9, height: UIScreen.main.bounds.height * 0.6)
-                .background(
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(.white)
-                )
-                .padding(.bottom, keyboardHandler.keyboardHeight/4)
-            }
-        }
-        .animation(.easeInOut(duration: 0.2), value: viewModel.isShowHistoryView)
-        .animation(.default, value: keyboardHandler.keyboardHeight)
     }
 }
 


### PR DESCRIPTION
## 📌 Summary
- resolve: #93 

<br>

## ✨ Description
식물일지 관련 뷰 UI를 수정하였습니다.
- 식물일지 작성 뷰와 식물일지 히스토리 상세 뷰를 팝업 뷰에서 풀스크린커버로 수정하였습니다.
- 식물일지 작성 뷰의 경우 스크롤뷰를 삽입하여 키보드 활성화시 뷰 화면 이동을 구현하였습니다.
```swift
ScrollViewReader { proxy in
                ScrollView(showsIndicators: false) {
                    selectImageView
                        .aspectRatio(1, contentMode: .fill)
                        .padding(.horizontal)
                        .padding(.vertical)
                    
                    writeHistoryView
                        .id("writeHistoryView")
                        .onChange(of: isFocused) { focused in
                            if focused {
                                withAnimation {
                                    proxy.scrollTo("writeHistoryView", anchor: .bottom)
                                }
                            }
                        }
                }
            }
```

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|스크린샷|
|:--:|:--:|:--:|
|히스토리 작성|<img src = "https://github.com/user-attachments/assets/9f23a040-680d-4f0c-848b-c024082e6a65" width ="250">|<img src = "https://github.com/user-attachments/assets/934928a3-da86-420f-bc6f-6d4467ab8d20" width ="250">|
|키보드 활성화|<img src = "https://github.com/user-attachments/assets/5ab0ad55-3e97-40d5-912d-9a0ac946bdc5" width ="250">|
|히스토리 상세|<img src = "https://github.com/user-attachments/assets/fff13515-23a7-4c59-9498-1c514209905b" width ="250">|

<br>

## 🗒️ Review Point
```
불필요한 코드가 남아있거나, 오류를 발견한 경우 코멘트를 남겨주세요! 바로 수정하겠습니다:-)
```
