### PR TITLE
fix: fix image crop view error

### DIFF
--- a/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
@@ -55,9 +55,6 @@ struct WriteHistoryView: View {
                 .onAppear {
                     isShowSelectImagePopup = false
                 }
-                .onDisappear {
-                    isShowCropView = true
-                }
         }
         .sheet(isPresented: $isShowPhotoLibraryPicker) {
             ImagePicker(selectedImage: $viewModel.selectedImage,


### PR DESCRIPTION
## 📌 Summary
- resolve: #108 

<br>

## ✨ Description
`WriteHistoryView`에서 카메라 취소 버튼을 눌렀을 때, `ImageCropView`가 등장하는 오류를 해결했습니다.
   - 아래 코드 삭제
```swift
.onDisappear {
                    isShowCropView = true
                }
```

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/d76613e4-b846-4594-9b20-1e9b7d0a4140" width ="250">|
