### PR TITLE
feat: implement daily mission limit

### DIFF
--- a/ForestTori/ForestTori/Source/Utils/Extension/Date+.swift
+++ b/ForestTori/ForestTori/Source/Utils/Extension/Date+.swift
@@ -15,4 +15,11 @@ extension Date {
 
         return dateFormatter.string(from: self)
     }
+    
+    static func fromString(_ dateString: String) -> Date? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        
+        return dateFormatter.date(from: dateString)
+    }
 }

--- a/ForestTori/ForestTori/Source/View/Main/MainView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/MainView.swift
@@ -56,6 +56,13 @@ struct MainView: View {
                 notificationManager.scheduleNotification(for: newPlantName)
             }
         }
+        .onAppear {
+            viewModel.checkMissionAvailability()
+            viewModel.startTimerToCheckDate()
+        }
+        .onDisappear {
+            viewModel.stopTimer()
+        }
     }
 }
 

--- a/ForestTori/ForestTori/Source/View/Main/PlantContentView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/PlantContentView.swift
@@ -40,7 +40,7 @@ struct PlantContentView: View {
             VStack(spacing: 0) {
                 ZStack(alignment: .bottom) {
                     dialogueBox
-                        .hidden(viewModel.plantStatuses[index]!.missionStatus == .receivingMission || viewModel.plantStatuses[index]!.missionStatus == .completed)
+                        .hidden(viewModel.plantStatuses[index]!.missionStatus == .receivingMission || (viewModel.plantStatuses[index]!.missionStatus == .completed && viewModel.canPerformMission))
                     
                     infoButton
                         .hidden(viewModel.plantStatuses[index]!.missionStatus == .inProgress && viewModel.plantStatuses[index]!.plant!.characterName == "목화나무")
@@ -154,7 +154,7 @@ extension PlantContentView {
                             .frame(width: 38, height: 38)
                             .foregroundColor(viewModel.plantStatuses[index]!.missionStatus == .done || viewModel.plantStatuses[index]!.missionStatus == .completed ? .greenPrimary : .brownSecondary)
                     }
-                    .disabled(viewModel.plantStatuses[index]!.missionStatus != .inProgress)
+                    .disabled(viewModel.plantStatuses[index]!.missionStatus != .inProgress || !viewModel.canPerformMission)
                 }
                 .padding(.horizontal, 20)
             }

--- a/ForestTori/ForestTori/Source/View/Main/PlantContentView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/PlantContentView.swift
@@ -40,7 +40,7 @@ struct PlantContentView: View {
             VStack(spacing: 0) {
                 ZStack(alignment: .bottom) {
                     dialogueBox
-                        .hidden(viewModel.plantStatuses[index]!.missionStatus == .receivingMission || (viewModel.plantStatuses[index]!.missionStatus == .completed && viewModel.canPerformMission))
+                        .hidden(viewModel.shouldHideDialogueBox(for: index))
                     
                     infoButton
                         .hidden(viewModel.plantStatuses[index]!.missionStatus == .inProgress && viewModel.plantStatuses[index]!.plant!.characterName == "목화나무")

--- a/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
@@ -220,8 +220,13 @@ class MainViewModel: ObservableObject {
     }
     
     func startTimerToCheckDate() {
-        timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
-            self?.checkMissionAvailability()
+        DispatchQueue.global(qos: .background).async {
+            let timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
+                self?.checkMissionAvailability()
+            }
+            
+            RunLoop.current.add(timer, forMode: .common)
+            RunLoop.current.run()
         }
     }
     

--- a/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
@@ -80,14 +80,14 @@ class MainViewModel: ObservableObject {
         if currentLineIndex < dialogues[currentDialogueIndex].lines.count {
             dialogueText = dialogues[currentDialogueIndex].lines[currentLineIndex]
         }
-
+        
         missionText = plant.missions[0].content
     }
     
     func showNextDialogue(index: Int) {
         if currentLineIndex == dialogues[currentDialogueIndex].lines.count {
             plantStatuses[index]?.missionStatus = .inProgress
-
+            
             if dialogues[currentDialogueIndex].type == "Ending" {
                 let today = Date().toString()
                 lastMissionDate = today
@@ -234,12 +234,18 @@ class MainViewModel: ObservableObject {
         withAnimation(.easeInOut(duration: 1)) {
             isShowNotAvailable = true
         }
-            
+        
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
             withAnimation(.easeInOut(duration: 1)) {
                 self.isShowNotAvailable = false
             }
         }
+    }
+    
+    func shouldHideDialogueBox(for index: Int) -> Bool {
+        guard let status = plantStatuses[index]?.missionStatus else { return true }
+        
+        return status == .receivingMission || (status == .completed && canPerformMission)
     }
     
     func openWebsite(urlString: String) {


### PR DESCRIPTION
## 📌 Summary
- resolve: #104

<br>

## ✨ Description
1. `MainViewModel`에 `canPerformMission`과 `lastMissionDate` 변수를 추가하여, 미션 수행 가능 여부와 마지막 미션 수행 시간을 저장/관리할 수 있도록 하였습니다.
```swift
@AppStorage("canPerformMission") var canPerformMission = true
@AppStorage("lastMissionDate") var lastMissionDate = ""
```

2. `checkMissionAvailability()` 함수를 통해 미션 수행 가능 여부를 확인할 수 있도록 하였고, 타이머를 설정하여 1분 단위로 이를 확인하도록 하였습니다. 
```swift
func checkMissionAvailability() {
        let today = Date().toString()
        if today != lastMissionDate {
            canPerformMission = true
        }
    }
    
func startTimerToCheckDate() {
        timer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
            self?.checkMissionAvailability()
        }
    }
    
func stopTimer() {
        timer?.invalidate()
        timer = nil
    }
```

3. `Date+`에 아래 함수를 추가하여, 문자열을 다시 `Date` 유형으로 변경하는 기능을 추가하였습니다.
```swift
static func fromString(_ dateString: String) -> Date? {
        let dateFormatter = DateFormatter()
        dateFormatter.dateFormat = "yyyy-MM-dd"
        
        return dateFormatter.date(from: dateString)
    }
```

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/e0170e23-58e4-4b52-b245-12fd5665f570"  width ="250">|

<br>

## 🗒️ Review Point
```
타이머를 사용해서 1분 단위로 미션 수행 가능 여부를 확인하고 있습니다. 
따라서, 타이머가 n시 n분 nn초에 시작한다면, 다음날 00시 00분 00초가 아닌 00시 00분 nn초에 canPerformMission 값이 갱신됩니다.
(초 단위로 수정 가능)
```
