### PR TITLE
fix: modify complete plant function

### DIFF
--- a/ForestTori/ForestTori/Source/Utils/Manager/GameManager.swift
+++ b/ForestTori/ForestTori/Source/Utils/Manager/GameManager.swift
@@ -64,7 +64,10 @@ class GameManager: ObservableObject {
             }
         }
         
-        user.selectedPlant = nil
+        saveUserDataToUserDefaults()
+    }
+    
+    func completeChapter() {
         user.chapterProgress += 1
         
         if user.chapterProgress < 5 {

--- a/ForestTori/ForestTori/Source/View/Main/MainView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/MainView.swift
@@ -45,8 +45,12 @@ struct MainView: View {
             .ignoresSafeArea()
         }
         .ignoresSafeArea()
+        .onChange(of: viewModel.isCompletePlant) { _ in
+            gameManager.completePlant()
+        }
         .onChange(of: viewModel.isShowEnding) { _ in
             gameManager.completePlant()
+            gameManager.completeChapter()
             withAnimation {
                 serviceStateViewModel.state = .ending
             }
@@ -183,7 +187,7 @@ extension MainView {
                     .environmentObject(viewModel)
                     .onAppear {
                         if gameManager.user.selectedPlant != nil {
-                            gameManager.completePlant()
+                            gameManager.completeChapter()
                         }
                     }
             }

--- a/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
@@ -18,6 +18,7 @@ class MainViewModel: ObservableObject {
     @AppStorage("totalProgressValue") var totalProgressValue = 0.0
     @AppStorage("canPerformMission") var canPerformMission = true
     @AppStorage("lastMissionDate") var lastMissionDate = ""
+    @AppStorage("isCompletePlant") var isCompletePlant = false
     
     @Published var plantStatuses = [PlantStatus(), PlantStatus(),PlantStatus()] {
         didSet {
@@ -133,6 +134,10 @@ class MainViewModel: ObservableObject {
         if currentTab < 2 {
             currentTab += 1
             resetData()
+            
+            withAnimation(.easeInOut(duration: 0.5)) {
+                isCompletePlant = true
+            }
         } else {
             if let fileName =  plantStatuses[currentTab].plant?.characterFileName, fileName.contains("Winter") {
                 isShowEnding = true


### PR DESCRIPTION
## 📌 Summary
- resolve: #121

<br>

## ✨ Description
- `GameManager`의 `completePlant()` 함수를 아래와 같이 두 함수로 분리하여, 
-  식물 완료와 챕터 완료가 별도의 함수를 통해 실행될 수 있도록 하였습니다.
```swift
    func completePlant() {
        if let plant = user.selectedPlant {
            if let data = dataManager.gardenPlants.first(where: {
                $0.id == plant.id
            }) {
                user.completedPlants[user.chapterProgress, default: []].append(data)
            }
        }
        
        saveUserDataToUserDefaults()
    }
    
    func completeChapter() {
        user.chapterProgress += 1
        
        if user.chapterProgress < 5 {
            chapter = dataManager.chapters[user.chapterProgress - 1]
        } else {
            isGameCompleted = true
        }
        
        saveUserDataToUserDefaults()
        saveChapterDataToUserDefaults()
    }
```

<br>

## 🗒️ Review Point
```
테스트하는 과정에서 UI/기능적으로 수정이 필요한 부분들을 발견하였습니다.
별도의 이슈를 통해 해당 부분들을 수정할 계획입니다. 
만약, 추가적으로 수정을 원하시는 부분이 있으시다면 공유해 주세요:)
```
