### PR TITLE
fix: fix write history view

### DIFF
--- a/ForestTori/ForestTori/Source/Utils/Extension/View+.swift
+++ b/ForestTori/ForestTori/Source/Utils/Extension/View+.swift
@@ -25,17 +25,19 @@ extension View {
     }
     
     func snapshot() -> UIImage {
-            let controller = UIHostingController(rootView: self)
-            let view = controller.view
-
-            let targetSize = CGSize(width: 358, height: 358)
-            view?.bounds = CGRect(origin: .zero, size: targetSize)
-            view?.backgroundColor = .clear
-
-            let renderer = UIGraphicsImageRenderer(size: targetSize)
-
-            return renderer.image { _ in
-                view?.drawHierarchy(in: controller.view.bounds, afterScreenUpdates: true)
-            }
+        let controller = UIHostingController(rootView: self)
+        let view = controller.view
+        
+        guard let uiView = view else { return UIImage() }
+        
+        let targetSize = uiView.intrinsicContentSize
+        view?.bounds = CGRect(origin: .zero, size: targetSize)
+        view?.backgroundColor = .clear
+        
+        let renderer = UIGraphicsImageRenderer(size: targetSize)
+        
+        return renderer.image { _ in
+            view?.drawHierarchy(in: controller.view.bounds, afterScreenUpdates: true)
         }
+    }
 }

--- a/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
@@ -93,45 +93,45 @@ struct WriteHistoryView: View {
 
 extension WriteHistoryView {
     private var hisoryViewHeader: some View {
-        VStack {
-            HStack {
-                Button {
-                    withAnimation {
-                        isShowHistoryView = false
-                        currentStatus = .inProgress
+            VStack {
+                ZStack {
+                    Text("성장일지")
+                        .font(.subtitleL)
+                    
+                    HStack {
+                        Button {
+                            withAnimation {
+                                isShowHistoryView = false
+                                currentStatus = .inProgress
+                            }
+                        } label: {
+                            Text(Image(systemName: "chevron.backward"))
+                                .bold()
+                                .foregroundStyle(.gray40)
+                        }
+                        
+                        Spacer()
+                        
+                        Button {
+                            viewModel.saveHistory()
+                            isComplete = true
+                        } label: {
+                            Text("완료")
+                                .font(.subtitleM)
+                                .bold()
+                                .foregroundStyle(viewModel.isCompleteButtonDisable ? .gray30 : .greenSecondary)
+                        }
+                        .disabled(viewModel.isCompleteButtonDisable)
                     }
-                } label: {
-                    Text(Image(systemName: "chevron.backward"))
-                        .bold()
-                        .foregroundStyle(.gray40)
+                    .padding(.leading, 8)
+                    .padding(.trailing, 16)
                 }
+                .padding(.top, 11)
+                .padding(.bottom, 6)
                 
-                Spacer()
-                
-                Text("성장일지")
-                    .font(.subtitleL)
-                
-                Spacer()
-                
-                Button {
-                    viewModel.saveHistory()
-                    isComplete = true
-                } label: {
-                    Text("완료")
-                        .font(.subtitleM)
-                        .bold()
-                        .foregroundStyle(viewModel.isCompleteButtonDisable ? .gray30 : .greenSecondary)
-                }
-                .disabled(viewModel.isCompleteButtonDisable)
-            }
-            .padding(.leading, 8)
-            .padding(.trailing, 16)
-            .padding(.top, 11)
-            .padding(.bottom, 6)
-            
-            Rectangle()
-                .fill(.gray30)
-                .frame(height: 0.33)
+                Rectangle()
+                    .fill(.gray30)
+                    .frame(height: 0.33)
         }
     }
     
@@ -270,5 +270,5 @@ extension WriteHistoryView {
 }
 
 #Preview {
-    MainView()
+    WriteHistoryView(isComplete: .constant(true), isShowHistoryView: .constant(true), currentStatus: .constant(.completed), plantName: "나팔꽃")
 }

--- a/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
@@ -93,45 +93,45 @@ struct WriteHistoryView: View {
 
 extension WriteHistoryView {
     private var hisoryViewHeader: some View {
-            VStack {
-                ZStack {
-                    Text("성장일지")
-                        .font(.subtitleL)
-                    
-                    HStack {
-                        Button {
-                            withAnimation {
-                                isShowHistoryView = false
-                                currentStatus = .inProgress
-                            }
-                        } label: {
-                            Text(Image(systemName: "chevron.backward"))
-                                .bold()
-                                .foregroundStyle(.gray40)
-                        }
-                        
-                        Spacer()
-                        
-                        Button {
-                            viewModel.saveHistory()
-                            isComplete = true
-                        } label: {
-                            Text("완료")
-                                .font(.subtitleM)
-                                .bold()
-                                .foregroundStyle(viewModel.isCompleteButtonDisable ? .gray30 : .greenSecondary)
-                        }
-                        .disabled(viewModel.isCompleteButtonDisable)
-                    }
-                    .padding(.leading, 8)
-                    .padding(.trailing, 16)
-                }
-                .padding(.top, 11)
-                .padding(.bottom, 6)
+        VStack {
+            ZStack {
+                Text("성장일지")
+                    .font(.subtitleL)
                 
-                Rectangle()
-                    .fill(.gray30)
-                    .frame(height: 0.33)
+                HStack {
+                    Button {
+                        withAnimation {
+                            isShowHistoryView = false
+                            currentStatus = .inProgress
+                        }
+                    } label: {
+                        Text(Image(systemName: "chevron.backward"))
+                            .bold()
+                            .foregroundStyle(.gray40)
+                    }
+                    
+                    Spacer()
+                    
+                    Button {
+                        viewModel.saveHistory()
+                        isComplete = true
+                    } label: {
+                        Text("완료")
+                            .font(.subtitleM)
+                            .bold()
+                            .foregroundStyle(viewModel.isCompleteButtonDisable ? .gray30 : .greenSecondary)
+                    }
+                    .disabled(viewModel.isCompleteButtonDisable)
+                }
+                .padding(.leading, 8)
+                .padding(.trailing, 16)
+            }
+            .padding(.top, 11)
+            .padding(.bottom, 6)
+            
+            Rectangle()
+                .fill(.gray30)
+                .frame(height: 0.33)
         }
     }
     
@@ -141,6 +141,8 @@ extension WriteHistoryView {
                 ZStack {
                     Image(uiImage: image)
                         .resizable()
+                        .scaledToFill()
+                        .frame(width: 358, height: 358) // snapshot과 동일한 사이즈
                         .clipShape(RoundedRectangle(cornerRadius: 8))
                         .overlay(alignment: .bottomTrailing) {
                             Button {
@@ -270,5 +272,5 @@ extension WriteHistoryView {
 }
 
 #Preview {
-    WriteHistoryView(isComplete: .constant(true), isShowHistoryView: .constant(true), currentStatus: .constant(.completed), plantName: "나팔꽃")
+    WriteHistoryView(isComplete: .constant(true), isShowHistoryView: .constant(true), currentStatus: .constant(.completed), plantName: "preview")
 }

--- a/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
@@ -23,6 +23,7 @@ struct WriteHistoryView: View {
     @Binding var currentStatus: MissionStatus
 
     private let placeHolder = "오늘의 활동과 감정을 적어보세요"
+    private let imageSize = UIScreen.main.bounds.width * 0.92
     var plantName: String
     
     var body: some View {
@@ -32,7 +33,6 @@ struct WriteHistoryView: View {
             ScrollViewReader { proxy in
                 ScrollView(showsIndicators: false) {
                     selectImageView
-                        .aspectRatio(1, contentMode: .fill)
                         .padding(.horizontal)
                         .padding(.vertical)
                     
@@ -142,8 +142,10 @@ extension WriteHistoryView {
                     Image(uiImage: image)
                         .resizable()
                         .scaledToFill()
-                        .frame(width: 358, height: 358) // snapshot과 동일한 사이즈
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                        .frame(width: imageSize, height: imageSize)
+                        .clipShape(
+                            RoundedRectangle(cornerRadius: 8)
+                        )
                         .overlay(alignment: .bottomTrailing) {
                             Button {
                                 withAnimation {
@@ -175,12 +177,13 @@ extension WriteHistoryView {
                 }
             }
         }
+        .frame(width: imageSize, height: imageSize)
     }
     
     private var writeHistoryView: some View {
         RoundedRectangle(cornerRadius: 5)
             .fill(Color.gray10)
-            .frame(height: 298)
+            .frame(width: UIScreen.main.bounds.width * 0.92, height: UIScreen.main.bounds.width * 0.75)
             .overlay {
                 RoundedRectangle(cornerRadius: 5)
                     .stroke(.brownSecondary, lineWidth: 2)


### PR DESCRIPTION
## 📌 Summary
- resolve: #131 

<br>

## ✨ Description
1. 헤더 중앙 정렬
- `ZStack`을 삽입하여 "성장일지" 문구가 화면 정중앙에 위치시키도록 하였습니다.
```swift
VStack {
            ZStack {
                Text("성장일지")
                    .font(.subtitleL)
                
                HStack {
                    Button {
                        withAnimation {
                            isShowHistoryView = false
                            currentStatus = .inProgress
                        }
                    } label: {
                        Text(Image(systemName: "chevron.backward"))
                            .bold()
                            .foregroundStyle(.gray40)
                    }
                    
                    Spacer()
                    
                    Button {
                        viewModel.saveHistory()
                        isComplete = true
                    } label: {
                        Text("완료")
                            .font(.subtitleM)
                            .bold()
                            .foregroundStyle(viewModel.isCompleteButtonDisable ? .gray30 : .greenSecondary)
                    }
                    .disabled(viewModel.isCompleteButtonDisable)
                }
                .padding(.leading, 8)
                .padding(.trailing, 16)
            }
            .padding(.top, 11)
            .padding(.bottom, 6)
            
            Rectangle()
                .fill(.gray30)
                .frame(height: 0.33)
        }
```

2. 이미지 비율 조정
- `snapshot`을 적용하지 않았을 때, 이미지가 상하로 늘어나는 현상이 발생하였습니다.
- `snapshot`과 사이즈를 동일하게 지정하였습니다.
```swift
Image(uiImage: image)
                        .resizable()
                        .scaledToFill()
                        .frame(width: 358, height: 358) // snapshot과 동일한 사이즈
                        .clipShape(RoundedRectangle(cornerRadius: 8))
```
```swift
func snapshot() -> UIImage {
            let controller = UIHostingController(rootView: self)
            let view = controller.view

            let targetSize = CGSize(width: 358, height: 358)
            view?.bounds = CGRect(origin: .zero, size: targetSize)
            view?.backgroundColor = .clear

            let renderer = UIGraphicsImageRenderer(size: targetSize)

            return renderer.image { _ in
                view?.drawHierarchy(in: controller.view.bounds, afterScreenUpdates: true)
            }
        }
```

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|전|후|
|:--:|:--:|:--:|
|헤더|<img src="https://github.com/user-attachments/assets/9cd46f36-f942-4f70-b36f-49b5d950df6e" width ="250">|<img src="https://github.com/user-attachments/assets/d2a9207e-ec8a-4762-aeff-5f0c42d42d34" width ="250">|
|이미지|<img src = "https://github.com/user-attachments/assets/61e1e7db-c9a8-4721-a9b1-ed8575567c06" width ="250">|<img src="https://github.com/user-attachments/assets/bf379898-356d-42cb-9536-9d1742ffcd9d" width ="250">|

<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
2번과 관련하여 여러 시도를 하였을 때, frame 사이즈를 지정하지 않고는 이미지 비율을 조정하기 어렵더군요. 혹시 더 좋은 의견 있으시다면 코멘트 남겨주세요:)
```
