### PR TITLE
fix: fix garden history view

### DIFF
--- a/ForestTori/ForestTori/Source/Utils/Component/Scenes/GardenScene.swift
+++ b/ForestTori/ForestTori/Source/Utils/Component/Scenes/GardenScene.swift
@@ -81,9 +81,9 @@ struct GardenScene: UIViewRepresentable {
                     }
                 }
                 
-                if let selectedName = hitNode.geometry?.name {
+                if let selectedName = hitNode.name {
                     if let selectedPlant = parent.chapterPlants?.first(where: {
-                        $0.garden3DFile.lowercased().contains(selectedName)
+                        $0.plantName.contains(selectedName)
                     }) {
                         parent.selectedPlant =  selectedPlant
                         parent.showHistoryView = true
@@ -129,6 +129,7 @@ extension GardenScene {
         let plantPositionZ = plant.gardenPositionZ
         
         for childNode in plantScene.rootNode.childNodes {
+            childNode.name = "\(plant.plantName)"
             plantNode.addChildNode(childNode)
         }
         

--- a/ForestTori/ForestTori/Source/View/Garden/HistoryDetailView.swift
+++ b/ForestTori/ForestTori/Source/View/Garden/HistoryDetailView.swift
@@ -31,27 +31,27 @@ struct HistoryDetailView: View {
 extension HistoryDetailView {
     private var viewHeader: some View {
         VStack {
-            HStack {
-                Button {
-                    withAnimation {
-                        selectedHistoryIndex = nil
-                        isShowHistoryDetailView = false
-                    }
-                } label: {
-                    Text(Image(systemName: "chevron.backward"))
-                        .bold()
-                        .foregroundStyle(.gray40)
-                }
-                
-                Spacer()
-                
+            ZStack {
                 Text(selectedHistory?.date ?? "0000.00.00")
                     .font(.subtitleL)
                 
-                Spacer()
+                HStack {
+                    Button {
+                        withAnimation {
+                            selectedHistoryIndex = nil
+                            isShowHistoryDetailView = false
+                        }
+                    } label: {
+                        Text(Image(systemName: "chevron.backward"))
+                            .bold()
+                            .foregroundStyle(.gray40)
+                    }
+                    
+                    Spacer()
+                }
+                .padding(.horizontal, 8)
                 
             }
-            .padding(.horizontal, 8)
             .padding(.top, 11)
             .padding(.bottom, 6)
             


### PR DESCRIPTION
## 📌 Summary
- resolve: #133 

<br>

## ✨ Description
1. 정원에서 식물을 탭했을 때, `HistoryView`가 등장하지 않는 오류를 수정
- `GardenScene`에서 식물 노드를 심을 때, 해당 노드에 이름을 부여하도록 구문 추가
```swift
for childNode in plantScene.rootNode.childNodes {
            childNode.name = "\(plant.plantName)"
            plantNode.addChildNode(childNode)
        }
```

2. 식물 히스토리 상세 뷰 헤더 정렬 수정
- `ZStack`을 이용하여 헤더의 날짜가 화면 기준 중앙에 위치하도록 수정하였습니다.
```swift
VStack {
            ZStack {
                Text(selectedHistory?.date ?? "0000.00.00")
                    .font(.subtitleL)
                
                HStack {
                    Button {
                        withAnimation {
                            selectedHistoryIndex = nil
                            isShowHistoryDetailView = false
                        }
                    } label: {
                        Text(Image(systemName: "chevron.backward"))
                            .bold()
                            .foregroundStyle(.gray40)
                    }
                    
                    Spacer()
                }
                .padding(.horizontal, 8)
                
            }
            .padding(.top, 11)
            .padding(.bottom, 6)
            
            Rectangle()
                .fill(.gray30)
                .frame(height: 0.33)
        }
    }
```

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|히스토리 뷰 표출|<img src = "https://github.com/user-attachments/assets/a0393783-ccfa-400c-bdff-c788f705aad1" width ="250">|
|상세 히스토리 뷰 헤더|<img src = "https://github.com/user-attachments/assets/9b757517-a5c2-4274-b905-2446528f9027" width ="250">|


<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
추가로 수정 필요한 부분 발견하시면, 디스코드에 공유해 주세요:)
```
