### PR TITLE
fix: fix onboarding views

### DIFF
--- a/ForestTori/ForestTori/Source/View/Onboarding/OnboardingCompletionView.swift
+++ b/ForestTori/ForestTori/Source/View/Onboarding/OnboardingCompletionView.swift
@@ -19,6 +19,7 @@ struct OnboardingCompletionView: View {
                 Image(.chapterThumbnail1)
                     .resizable()
                     .scaledToFit()
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
                     .padding(20)
                 
                 OnboardingTextBox(texts: onboardingViewModel.onboardingCompletionText)

--- a/ForestTori/ForestTori/Source/View/Onboarding/OnboardingIntroductionView.swift
+++ b/ForestTori/ForestTori/Source/View/Onboarding/OnboardingIntroductionView.swift
@@ -25,18 +25,14 @@ struct OnboardingIntroductionView: View {
                     introductionContent(data: introduction)
                 }
             }
-            Button {
-                onboardingViewModel.type = .naming
-            } label: {
-                Text(doneButtonLabel)
-                    .padding()
-                    .frame(maxWidth: .infinity)
-                    .foregroundColor(.yellowTertiary)
-                    .background(.brownPrimary)
-                    .cornerRadius(50)
-            }
-            .hidden(isHidden)
-            .padding(20)
+            OnboardingDoneButton(action: onboardingViewModel.moveToOnboardingIntroductionView, label: doneButtonLabel)
+                .foregroundColor(.yellowTertiary)
+                .background {
+                    RoundedRectangle(cornerRadius: 50)
+                        .fill(.brownPrimary)
+                }
+                .hidden(isHidden)
+                .padding(20)
         }
         .toolbar {
             OnboardingSkipButton(action: onboardingViewModel.moveToOnboardingNamingView)
@@ -53,24 +49,15 @@ struct OnboardingIntroductionView: View {
 extension OnboardingIntroductionView {
     @ViewBuilder private func introductionContent(data: OnboardingIntroductionData) -> some View {
         VStack(spacing: 30) {
-            HStack {
-                Image(systemName: leftCompactChevron)
-                    .foregroundColor(.brownSecondary)
-                    .hidden(data.description != firstPageDescription)
-                
-                Image(data.imageName)
-                    .resizable()
-                    .scaledToFit()
-                
-                Image(systemName: rightCompactChevron)
-                    .foregroundColor(.brownSecondary)
-                    .hidden(data.description != lastPageDescription)
-            }
+            Image(data.imageName)
+                .resizable()
+                .scaledToFit()
+            
             OnboardingTextBox(texts: data.introductionTexts)
                 .font(.titleM)
                 .foregroundColor(.gray50)
         }
-        .padding(20)
+        .padding(32)
         .onAppear {
             showDoneButton(description: data.description)
         }

--- a/ForestTori/ForestTori/Source/ViewModel/OnboardingViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/OnboardingViewModel.swift
@@ -147,16 +147,16 @@ extension OnboardingViewModel {
         
         let secondText = [
             OnboardingText(text: "멋진 이름이네요."),
-            OnboardingText(text: "\(Text(userName).foregroundColor(.greenPrimary))\(Text("토리:)").foregroundColor(.greenPrimary))"),
+            OnboardingText(text: "\(Text(userName).foregroundColor(.greenPrimary))\(Text("토리").foregroundColor(.greenPrimary)) :)"),
         ]
         
         let thirdText = [
-            OnboardingText(text: "여기 \(Text(userName).foregroundColor(.greenPrimary))를 위해"),
+            OnboardingText(text: "여기 \(Text(userName).foregroundColor(.greenPrimary))\(Text("토리").foregroundColor(.greenPrimary))를 위해"),
             OnboardingText(text: "신비한 화분을 줄게요."),
         ]
         
         let fourthText = [
-            OnboardingText(text: "이제부터 \(Text(userName).foregroundColor(.greenPrimary))토리의"),
+            OnboardingText(text: "이제부터 \(Text(userName).foregroundColor(.greenPrimary))\(Text("토리").foregroundColor(.greenPrimary))의"),
             OnboardingText(text: "마법 능력으로 식물을 잘 키워주세요."),
         ]
         
@@ -167,7 +167,7 @@ extension OnboardingViewModel {
         let text = [
             OnboardingText(text: "첫 챕터는 새로운 시작을 의미하는"),
             OnboardingText(text: "새싹이 반짝이는 계절, 봄이에요."),
-            OnboardingText(text: "\(Text(userName).foregroundColor(.greenPrimary))토리의 시작을 응원할게요!"),
+            OnboardingText(text: "\(Text(userName).foregroundColor(.greenPrimary))\(Text("토리").foregroundColor(.greenPrimary))의 시작을 응원할게요!"),
         ]
         
         onboardingCompletionText = text


### PR DESCRIPTION
## 📌 Summary
- resolve: #138 

<br>

## ✨ Description
온보딩 테스트 결과, 수정이 필요한 부분에 대해서 정리하였습니다.

1. 온보딩 대사 관련
- [닉네임 입력 후] /(userName)를 위해 신비한 화분을 줄게요." => "/(userName)토리" 로 수정
- [챕터 소개] 토리 문구 추가 + 토리에 하이라이트 추가
2. 온보딩 소개 뷰
- `준비됐어요` 버튼 수정 ➡️ `onboardingDoneButton` 적용
- 탭뷰 좌우에 쉐브론 심볼 제거
4. 온보딩 완료 뷰
- 썸네일에 radius 적용

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|스크린샷|스크린샷|
|:--:|:--:|:--:|:--:|
|온보딩|<img src = "https://github.com/user-attachments/assets/42c8b6f8-b554-4313-9034-7554ef21a063" height ="250">|<img src = "https://github.com/user-attachments/assets/1c5d892c-6769-42c4-806d-ffa4d5f522a8" height ="250">|<img src = "https://github.com/user-attachments/assets/fe19b3b7-6f56-4071-b8cc-38445780b6da" height ="250">|

<br>

## 🗒️ Review Point
```
온보딩 테스트 이후 디스코드에 반영된 결과를 참고하여 작업 진행하였습니다. 혹시나,,,제가 실수로 누락한 부분이 있다면 알려주세요:)
```
