### PR TITLE
fix: fix notification lines

### DIFF
--- a/ForestTori/ForestTori/Source/Utils/Manager/GameManager.swift
+++ b/ForestTori/ForestTori/Source/Utils/Manager/GameManager.swift
@@ -20,6 +20,7 @@ class GameManager: ObservableObject {
     @Published var chapter: Chapter
     
     private let dataManager = DataManager()
+    static let instance = GameManager()
     
     init() {
         // 진행 중인 정보를 유지하기 위해 UserDefault에 저장

--- a/ForestTori/ForestTori/Source/Utils/Manager/NotificationManager.swift
+++ b/ForestTori/ForestTori/Source/Utils/Manager/NotificationManager.swift
@@ -12,6 +12,7 @@ class NotificationManager: ObservableObject {
     @Published var isNotificationSet = false
     
     static let instance = NotificationManager()
+    
     private init() { }
     
     func requestAuthorization() {
@@ -31,15 +32,17 @@ class NotificationManager: ObservableObject {
         }
     }
     
-    func scheduleNotification(for plantName: String) {
+    func scheduleNotification(line: String) {
         // 선택 식물이 바뀌면 과거에 설정된 알림 대기를 모두 지움
         UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
         
         let times: [(hour: Int, minute: Int)] = [(10, 0), (20, 0)]
+        
         for time in times {
             let content = UNMutableNotificationContent()
             content.title = "숲토리"
-            content.body = "\(plantName)이/가 토리를 기다리고 있어요:)\n오늘 미션을 수행해서 \(plantName)을/를 키워보아요!"
+            
+            content.body = line
             content.sound = UNNotificationSound.default
             
             var dateComponents = DateComponents()
@@ -57,5 +60,9 @@ class NotificationManager: ObservableObject {
                 }
             }
         }
+    }
+    
+    func removeNotification() {
+        UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
     }
 }

--- a/ForestTori/ForestTori/Source/View/Main/MainView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/MainView.swift
@@ -77,14 +77,13 @@ struct MainView: View {
                 serviceStateViewModel.state = .ending
             }
         }
-        .onChange(of: gameManager.user.selectedPlant?.name) { newPlantName in
-            if let newPlantName {
-                notificationManager.scheduleNotification(for: newPlantName)
-            }
+        .onChange(of: gameManager.isPlantSelected) { _ in
+            viewModel.setNotification()
         }
         .onAppear {
             viewModel.checkMissionAvailability()
             viewModel.startTimerToCheckDate()
+            viewModel.setNotification()
         }
         .onDisappear {
             viewModel.stopTimer()

--- a/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
@@ -273,6 +273,26 @@ class MainViewModel: ObservableObject {
             UIApplication.shared.open(url)
         }
     }
+    
+    func setNotification() {
+        // 미션을 수행할 수 있는 경우
+        if canPerformMission {
+            // 식물을 선택한 경우
+            if GameManager.instance.isPlantSelected {
+                if let newPlantName = GameManager.instance.user.selectedPlant?.name {
+                    let line = "\(newPlantName)이 토리를 기다리고 있어요:)\n오늘 미션을 수행해서 \(newPlantName)을 키워보아요!"
+                    NotificationManager.instance.scheduleNotification(line: line)
+                }
+            // 식물을 선택하지 않은 경우
+            } else {
+                let line = "새 식물이 토리를 기다리고 있어요:)\n화분에 새 식물을 심어보아요!"
+                NotificationManager.instance.scheduleNotification(line: line)
+            }
+        // 미션을 수행할 수 없는 경우(오늘 플레이를 마친 경우) -> 알림 없음
+        } else {
+            NotificationManager.instance.removeNotification()
+        }
+    }
 }
 
 enum MissionStatus: String, Codable {


### PR DESCRIPTION
## 📌 Summary
- resolve: #145 

<br>

## ✨ Description
- 사용자의 플레이 상황에 따라 적절한 알림 문구를 보여줄 수 있도록 수정하였습니다.
```swift
func setNotification() {
        // 미션을 수행할 수 있는 경우
        if canPerformMission {
            // 식물을 선택한 경우
            if GameManager.instance.isPlantSelected {
                if let newPlantName = GameManager.instance.user.selectedPlant?.name {
                    let line = "\(newPlantName)이 토리를 기다리고 있어요:)\n오늘 미션을 수행해서 \(newPlantName)을 키워보아요!"
                    NotificationManager.instance.scheduleNotification(line: line)
                }
            // 식물을 선택하지 않은 경우
            } else {
                let line = "새 식물이 토리를 기다리고 있어요:)\n화분에 새 식물을 심어보아요!"
                NotificationManager.instance.scheduleNotification(line: line)
            }
        // 미션을 수행할 수 없는 경우(오늘 플레이를 마친 경우) -> 알림 없음
        } else {
            NotificationManager.instance.removeNotification()
        }
    }
```

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|식물 X|<img src = "https://github.com/user-attachments/assets/f4cea7e8-c3d7-4123-a0ad-c8d7ae0f65b7" width ="250">|
|식물 O|<img src = "https://github.com/user-attachments/assets/032228b0-46e2-4a8f-8a81-92856cc37e8e" width ="250">|

<br>