### PR TITLE
fix: fix mission box error

### DIFF
--- a/ForestTori/ForestTori/Source/View/Main/PlantContentView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/PlantContentView.swift
@@ -167,7 +167,6 @@ extension PlantContentView {
                     Spacer()
                     
                     Button {
-                        viewModel.plantStatuses[index].missionStatus = .done
                         viewModel.isShowHistoryView = true
                     } label: {
                         Image(systemName: viewModel.checkMissionBox(for: index) ? "checkmark.circle.fill" : "circle")

--- a/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
+++ b/ForestTori/ForestTori/Source/ViewModel/MainViewModel.swift
@@ -265,7 +265,7 @@ class MainViewModel: ObservableObject {
     func checkMissionBox(for index: Int) -> Bool {
         let status = plantStatuses[index].missionStatus
         
-        return status == .done || status == .completed || (status == .inProgress && !canPerformMission)
+        return status == .completed || (status == .inProgress && !canPerformMission)
     }
     
     func openWebsite(urlString: String) {
@@ -300,7 +300,6 @@ enum MissionStatus: String, Codable {
     case none             // 미션 없음
     case receivingMission // 미션을 받는 중
     case inProgress       // 미션 하는 중
-    case done             // 미션 완료
     case completed        // 식물일지 작성까지 완료
 }
 


### PR DESCRIPTION
## 📌 Summary
- resolve: #147 

<br>

## ✨ Description
성장일지 강제 종료 시, 발생하는 미션 박스 미표출 오류를 수정하였습니다.
- `WirteHistoryView`가 표출되면서 `missionStatus`가 `.inProgress`에서 `.done`으로 변경되는 것이 원인이었으며,
- 해당 상태값은 `MainViewModel.checkMissionBox(:)` 외에는 쓰이지 않기 때문에
- `.done`일 때의 뷰 제어 로직을 추가하는 것보다 이를 제거하는 것이 더 용이하다고 판단하였습니다.
- 따라서, 아래와 같이 `missionStatus`와 `checkMissionBox` 등을 수정하였습니다.
```swift
// MainViewModel

func checkMissionBox(for index: Int) -> Bool {
        let status = plantStatuses[index].missionStatus
        
        // return status == .done || status == .completed || (status == .inProgress && !canPerformMission)
        return status == .completed || (status == .inProgress && !canPerformMission)
    }

enum MissionStatus: String, Codable {
    case none             // 미션 없음
    case receivingMission // 미션을 받는 중
    case inProgress       // 미션 하는 중
    // case done             // 미션 완료
    case completed        // 식물일지 작성까지 완료
}
``` 

```swift
// PlantContentView

      Button {
                        // viewModel.plantStatuses[index].missionStatus = .done
                        viewModel.isShowHistoryView = true
                    }
```

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/d8923ff6-256d-4817-b485-e72651f3c7bf" width ="250">|

<br>

## 🗒️ Review Point
```
자주 사용하지 않는 상태값이기 때문에, 해당 상태값을 위한 추가 제어문을 작성하는 것보다 아예 삭제하는 것이 더 용이하다고 판단하였습니다. (앞으로의 코드 관리 및 코드 단순화를 바탕으로) 이와 관련하여 헬리아 의견은 어떤지 궁금합니다! 다른 의견 있으시면 코멘트 남겨주세요❤️
```
