### PR TITLE
fix: fix image crop error

### DIFF
--- a/ForestTori/ForestTori/Source/View/Main/History/ImageCropView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/History/ImageCropView.swift
@@ -36,7 +36,7 @@ struct ImageCropView: View {
                     ToolbarItemGroup(placement: .bottomBar) {
                         HStack {
                             Button("취소") {
-                                onCrop(nil, false) // 취소 시 false 전달
+                                onCrop(nil, false)
                                 dismiss()
                             }
 
@@ -54,7 +54,6 @@ struct ImageCropView: View {
                 }
         }
         .onAppear {
-            // 뷰가 나타날 때마다 상태 초기화
             resetCropState()
         }
     }

--- a/ForestTori/ForestTori/Source/View/Main/History/ImageCropView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/History/ImageCropView.swift
@@ -36,6 +36,7 @@ struct ImageCropView: View {
                     ToolbarItemGroup(placement: .bottomBar) {
                         HStack {
                             Button("취소") {
+                                onCrop(nil, false) // 취소 시 false 전달
                                 dismiss()
                             }
 
@@ -45,13 +46,24 @@ struct ImageCropView: View {
                                 let image = imageView(true).offset(y: yOffset)
                                 let img = image.snapshot()
                                 onCrop(img, true)
-                                isShowCropView = false
+                                dismiss()
                             }
                         }
                         .foregroundColor(.white)
                     }
                 }
         }
+        .onAppear {
+            // 뷰가 나타날 때마다 상태 초기화
+            resetCropState()
+        }
+    }
+    
+    private func resetCropState() {
+        scale = 1
+        lastScale = 0
+        offset = .zero
+        lastStoredOffset = .zero
     }
 
     @ViewBuilder
@@ -160,9 +172,4 @@ struct ImageCropView: View {
             }
         }
     }
-}
-
-#Preview {
-    ImageCropView(isShowCropView: .constant(true), onCrop: { _, _ in
-    })
 }

--- a/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
@@ -20,7 +20,7 @@ struct WriteHistoryView: View {
     @State private var isShowPhotoLibraryPicker = false
     @State private var isShowPermissionAlert = false
     @State private var isShowCropView = false
-    @State private var tempSelectedImage: UIImage? // 임시 이미지 저장용
+    @State private var tempSelectedImage: UIImage?
     
     @Binding var isComplete: Bool
     @Binding var isShowHistoryView: Bool
@@ -76,7 +76,7 @@ struct WriteHistoryView: View {
                 if isConfirmed, let croppedImage = croppedImage {
                     viewModel.selectedImage = croppedImage
                 }
-                // 크롭뷰 닫힐 때 임시 이미지 정리
+
                 tempSelectedImage = nil
                 isShowCropView = false
             }
@@ -91,7 +91,6 @@ struct WriteHistoryView: View {
             }
         }
         .onChange(of: tempSelectedImage) { newImage in
-            // 이미지가 선택되면 크롭뷰 표시
             if newImage != nil {
                 isShowCropView = true
             }
@@ -109,7 +108,7 @@ struct WriteHistoryView: View {
 
 extension WriteHistoryView {
     private var hisoryViewHeader: some View {
-        VStack {
+        VStack(spacing: 0) {
             ZStack {
                 Text("성장일지")
                     .font(.subtitleL)
@@ -121,9 +120,10 @@ extension WriteHistoryView {
                             currentStatus = .inProgress
                         }
                     } label: {
-                        Text(Image(systemName: "chevron.backward"))
-                            .bold()
+                        Image(systemName: "chevron.backward")
+                            .font(.system(size: 18, weight: .medium))
                             .foregroundStyle(.gray40)
+                            .frame(height: 40)
                     }
                     
                     Spacer()
@@ -136,18 +136,18 @@ extension WriteHistoryView {
                             .font(.subtitleM)
                             .bold()
                             .foregroundStyle(viewModel.isCompleteButtonDisable ? .gray30 : .greenSecondary)
+                            .frame(height: 44)
                     }
                     .disabled(viewModel.isCompleteButtonDisable)
                 }
-                .padding(.leading, 8)
-                .padding(.trailing, 16)
+                .padding(.horizontal, 16)
             }
-            .padding(.top, 11)
+            .padding(.top, 8)
             .padding(.bottom, 6)
             
             Rectangle()
                 .fill(.gray30)
-                .frame(height: 0.33)
+                .frame(height: 0.5)
         }
     }
     
@@ -254,7 +254,7 @@ extension WriteHistoryView {
             VStack {
                 Button {
                     isFocused = false
-                    isShowSelectImagePopup = false // 팝업 닫기
+                    isShowSelectImagePopup = false
                     if AVCaptureDevice.authorizationStatus(for: .video) == .authorized {
                         isShowCameraPicker = true
                     } else {
@@ -273,7 +273,7 @@ extension WriteHistoryView {
                 
                 Button {
                     isFocused = false
-                    isShowSelectImagePopup = false // 팝업 닫기
+                    isShowSelectImagePopup = false
                     let photoStatus = PHPhotoLibrary.authorizationStatus(for: .readWrite)
                     if photoStatus == .authorized || photoStatus == .limited {
                         isShowPhotoLibraryPicker = true

--- a/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
+++ b/ForestTori/ForestTori/Source/View/Main/History/WriteHistoryView.swift
@@ -19,7 +19,8 @@ struct WriteHistoryView: View {
     @State private var isShowCameraPicker = false
     @State private var isShowPhotoLibraryPicker = false
     @State private var isShowPermissionAlert = false
-    @State var isShowCropView = false
+    @State private var isShowCropView = false
+    @State private var tempSelectedImage: UIImage? // 임시 이미지 저장용
     
     @Binding var isComplete: Bool
     @Binding var isShowHistoryView: Bool
@@ -52,7 +53,7 @@ struct WriteHistoryView: View {
             }
         }
         .fullScreenCover(isPresented: $isShowCameraPicker) {
-            ImagePicker(selectedImage: $viewModel.selectedImage,
+            ImagePicker(selectedImage: $tempSelectedImage,
                         sourceType: .camera)
             .ignoresSafeArea()
             .onAppear {
@@ -60,27 +61,24 @@ struct WriteHistoryView: View {
             }
         }
         .sheet(isPresented: $isShowPhotoLibraryPicker) {
-            ImagePicker(selectedImage: $viewModel.selectedImage,
+            ImagePicker(selectedImage: $tempSelectedImage,
                         sourceType: .photoLibrary)
             .ignoresSafeArea()
             .onAppear {
                 isShowSelectImagePopup = false
             }
-            .onDisappear {
-                isShowCropView = true
-            }
         }
         .sheet(isPresented: $isShowCropView) {
-            isShowCropView = false
-            isShowCameraPicker = false
-            isShowPhotoLibraryPicker = false
-        } content: {
             ImageCropView(
-                isShowCropView: $isShowCropView, image: viewModel.selectedImage
-            ) { croppedImage, _ in
-                if let croppedImage {
+                isShowCropView: $isShowCropView,
+                image: tempSelectedImage
+            ) { croppedImage, isConfirmed in
+                if isConfirmed, let croppedImage = croppedImage {
                     viewModel.selectedImage = croppedImage
                 }
+                // 크롭뷰 닫힐 때 임시 이미지 정리
+                tempSelectedImage = nil
+                isShowCropView = false
             }
         }
         .alert("사진 혹은 카메라 접근이 허용되어 있지 않습니다. 설정으로 이동하시겠습니까?", isPresented: $isShowPermissionAlert) {
@@ -90,6 +88,12 @@ struct WriteHistoryView: View {
                    UIApplication.shared.canOpenURL(url) {
                     UIApplication.shared.open(url)
                 }
+            }
+        }
+        .onChange(of: tempSelectedImage) { newImage in
+            // 이미지가 선택되면 크롭뷰 표시
+            if newImage != nil {
+                isShowCropView = true
             }
         }
         .onTapGesture {
@@ -250,6 +254,7 @@ extension WriteHistoryView {
             VStack {
                 Button {
                     isFocused = false
+                    isShowSelectImagePopup = false // 팝업 닫기
                     if AVCaptureDevice.authorizationStatus(for: .video) == .authorized {
                         isShowCameraPicker = true
                     } else {
@@ -268,6 +273,7 @@ extension WriteHistoryView {
                 
                 Button {
                     isFocused = false
+                    isShowSelectImagePopup = false // 팝업 닫기
                     let photoStatus = PHPhotoLibrary.authorizationStatus(for: .readWrite)
                     if photoStatus == .authorized || photoStatus == .limited {
                         isShowPhotoLibraryPicker = true
@@ -293,8 +299,4 @@ extension WriteHistoryView {
             Spacer(minLength: 56)
         }
     }
-}
-
-#Preview {
-    WriteHistoryView(isComplete: .constant(true), isShowHistoryView: .constant(true), currentStatus: .constant(.completed), plantName: "preview")
 }


### PR DESCRIPTION
## 📌 Summary
<!-- 이슈 번호
     이슈가 없다면 이 작업을 하게 된 이유 
     작업 내용 요약 -->
- resolve: #141 

<br>

## ✨ Description
<!-- 작업 내용 -->
- historyView에서 사진 선택 / 촬영 시 발생하는 오류를 해결 했습니다.
- 기존에 사진 선택 후 취소 버튼 클릭 시 이미지 크롭 화면이 나타나거나 카메라 촬영 시 이미지 크롭뷰가 나타나지 않는 등 전체적으로 오류가 발생했습니다. 
- 해당 문제는 `ImagePicker` 가 disappear 될 때 무조건 cropView가 나타나도록 작성되어 있어서 발생하는 문제였습니다. 
- 또한, `ImageCropView`에서 취소 시 상태를 초기화 하지 않고 dismiss만 호출했기 때문에 정상적으로 작동하지 않았습니다.

<br>

- `tempSelectedImage` 라는 변수를 선언해 이미지를 임시로 저장할 수 있도록 하였습니다. 크롭 완료 후에만 실제 `selectedImage`에 저장될 수 있도록 수정하였습니다.
- 또한 `ImageCropView`에서 나타날 때마다 상태를 초기화 하도록 `resetCropState` 함수를 구현했습니다.
``` swift
private func resetCropState() {
    scale = 1
    lastScale = 0
    offset = .zero
    lastStoredOffset = .zero
}
```

<br>

- WriteHistoryView header 부분 UI를 살짝 수정했습니다.
- 양 옆에 padding을 추가하고, 전체적으로 가운데에 위치하도록 수정했습니다.

<br>

## 📸 Screenshot
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기존|변경|
|:--:|:--:|
|<img src = "https://github.com/user-attachments/assets/e578a87a-723e-4510-ae55-d55ffddc77ac" width ="250">|<img src = "https://github.com/user-attachments/assets/20cd8e98-6c3f-4634-b51b-a4ec358646bc" width ="250">|

<br>

## 🗒️ Review Point
<!-- 추가 필요한 사항이나 하고픈 말
     Reviewer 한테 요청하고 싶은 것들
     코드리뷰 요청하고 싶은 것들.. 등등 -->
```
이 곳에서 리뷰포인트를 작성해주세요.
```
